### PR TITLE
 Meal 모델을 수정하였습니다.

### DIFF
--- a/NyamNyam/NyamNyam/Network/Model/Meal.swift
+++ b/NyamNyam/NyamNyam/Network/Model/Meal.swift
@@ -22,9 +22,14 @@ enum Cafeteria {
     case staff
 }
 
+enum MealType {
+    case normal
+    case special
+}
+
 struct Meal: Hashable {
     let mealTime: MealTime
-    let type: String
+    let type: MealType
     let cafeteria: Cafeteria
     let price: String
     let menu: String


### PR DESCRIPTION
close #16 

기존에는 모든 식단의 운영시간이 동일하다고 생각하여 따로 Meal Type의 구분을 두지 않았지만,

유일하게 참슬기 특식의 경우에만 일반식과 시간이 달라서 Type을 `normal`과 `special`로 구분하려고 합니다.


다음과 같이 수정되었습니다.
``` swift
enum MealType {
    case normal
    case special
}

struct Meal: Hashable {
    let mealTime: MealTime
    let type: MealType
    let cafeteria: Cafeteria
    let price: String
    let menu: String
    let date: Date
}
```