### PR TITLE
학식의 정보를 보여주는 ScrollView가 올라가게 될 캐러셀을 만들었습니다.

### DIFF
--- a/NyamNyam/NyamNyam.xcodeproj/project.pbxproj
+++ b/NyamNyam/NyamNyam.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		AB2D2C0129B8271C0015CB10 /* CafeteriaSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2D2C0029B8271C0015CB10 /* CafeteriaSelectView.swift */; };
 		AB2FDAAE29B84CC7001746DB /* CafeteriaButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2FDAAD29B84CC7001746DB /* CafeteriaButton.swift */; };
 		AB2FDAB229B8D4B4001746DB /* ContentCarouselModuleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2FDAB129B8D4B4001746DB /* ContentCarouselModuleViewController.swift */; };
+		ABBDF69129B9C53C00E9347A /* CarouselCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABBDF69029B9C53C00E9347A /* CarouselCell.swift */; };
 		ABEAFBCB29AC9ED3002C3119 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABEAFBCA29AC9ED3002C3119 /* AppDelegate.swift */; };
 		ABEAFBCD29AC9ED3002C3119 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABEAFBCC29AC9ED3002C3119 /* SceneDelegate.swift */; };
 		ABEAFBCF29AC9ED3002C3119 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABEAFBCE29AC9ED3002C3119 /* HomeViewController.swift */; };
@@ -56,6 +57,7 @@
 		AB2D2C0029B8271C0015CB10 /* CafeteriaSelectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CafeteriaSelectView.swift; sourceTree = "<group>"; };
 		AB2FDAAD29B84CC7001746DB /* CafeteriaButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CafeteriaButton.swift; sourceTree = "<group>"; };
 		AB2FDAB129B8D4B4001746DB /* ContentCarouselModuleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCarouselModuleViewController.swift; sourceTree = "<group>"; };
+		ABBDF69029B9C53C00E9347A /* CarouselCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarouselCell.swift; sourceTree = "<group>"; };
 		ABEAFBC729AC9ED3002C3119 /* NyamNyam.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NyamNyam.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		ABEAFBCA29AC9ED3002C3119 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		ABEAFBCC29AC9ED3002C3119 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -123,9 +125,18 @@
 			isa = PBXGroup;
 			children = (
 				AB2FDAB129B8D4B4001746DB /* ContentCarouselModuleViewController.swift */,
+				ABBDF68F29B9C52000E9347A /* Components */,
 			);
 			name = ContentCarouselModule;
 			path = ../ContentCarouselModule;
+			sourceTree = "<group>";
+		};
+		ABBDF68F29B9C52000E9347A /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				ABBDF69029B9C53C00E9347A /* CarouselCell.swift */,
+			);
+			path = Components;
 			sourceTree = "<group>";
 		};
 		ABEAFBBE29AC9ED3002C3119 = {
@@ -446,6 +457,7 @@
 				ABEAFC0729ACA4E5002C3119 /* String+.swift in Sources */,
 				AB2FDAAE29B84CC7001746DB /* CafeteriaButton.swift in Sources */,
 				ABEAFC1D29AE6337002C3119 /* CampusSelectView.swift in Sources */,
+				ABBDF69129B9C53C00E9347A /* CarouselCell.swift in Sources */,
 				ABFC439129AFA7C600EB9439 /* Pallete.swift in Sources */,
 				ABEAFBCD29AC9ED3002C3119 /* SceneDelegate.swift in Sources */,
 			);

--- a/NyamNyam/NyamNyam.xcodeproj/project.pbxproj
+++ b/NyamNyam/NyamNyam.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		AB2D2C0129B8271C0015CB10 /* CafeteriaSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2D2C0029B8271C0015CB10 /* CafeteriaSelectView.swift */; };
 		AB2FDAAE29B84CC7001746DB /* CafeteriaButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2FDAAD29B84CC7001746DB /* CafeteriaButton.swift */; };
+		AB2FDAB229B8D4B4001746DB /* ContentCarouselModuleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2FDAB129B8D4B4001746DB /* ContentCarouselModuleViewController.swift */; };
 		ABEAFBCB29AC9ED3002C3119 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABEAFBCA29AC9ED3002C3119 /* AppDelegate.swift */; };
 		ABEAFBCD29AC9ED3002C3119 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABEAFBCC29AC9ED3002C3119 /* SceneDelegate.swift */; };
 		ABEAFBCF29AC9ED3002C3119 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABEAFBCE29AC9ED3002C3119 /* HomeViewController.swift */; };
@@ -54,6 +55,7 @@
 /* Begin PBXFileReference section */
 		AB2D2C0029B8271C0015CB10 /* CafeteriaSelectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CafeteriaSelectView.swift; sourceTree = "<group>"; };
 		AB2FDAAD29B84CC7001746DB /* CafeteriaButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CafeteriaButton.swift; sourceTree = "<group>"; };
+		AB2FDAB129B8D4B4001746DB /* ContentCarouselModuleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCarouselModuleViewController.swift; sourceTree = "<group>"; };
 		ABEAFBC729AC9ED3002C3119 /* NyamNyam.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NyamNyam.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		ABEAFBCA29AC9ED3002C3119 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		ABEAFBCC29AC9ED3002C3119 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -115,6 +117,15 @@
 				AB2FDAAD29B84CC7001746DB /* CafeteriaButton.swift */,
 			);
 			path = CafeteriaSelectViewComponents;
+			sourceTree = "<group>";
+		};
+		AB2FDAB029B8D478001746DB /* ContentCarouselModule */ = {
+			isa = PBXGroup;
+			children = (
+				AB2FDAB129B8D4B4001746DB /* ContentCarouselModuleViewController.swift */,
+			);
+			name = ContentCarouselModule;
+			path = ../ContentCarouselModule;
 			sourceTree = "<group>";
 		};
 		ABEAFBBE29AC9ED3002C3119 = {
@@ -247,6 +258,7 @@
 			isa = PBXGroup;
 			children = (
 				ABEAFC1629ADC24D002C3119 /* OptionSelectModule */,
+				AB2FDAB029B8D478001746DB /* ContentCarouselModule */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -422,6 +434,7 @@
 				ABEAFC1F29AE6769002C3119 /* UserDefaults+.swift in Sources */,
 				ABEAFC0429ACA4B1002C3119 /* Date+.swift in Sources */,
 				ABEAFC0D29ACA59E002C3119 /* HomeViewModel.swift in Sources */,
+				AB2FDAB229B8D4B4001746DB /* ContentCarouselModuleViewController.swift in Sources */,
 				ABEAFC1B29AE24B2002C3119 /* Observable.swift in Sources */,
 				ABEAFC1529AD2F36002C3119 /* Campus.swift in Sources */,
 				ABEAFC1329AD279A002C3119 /* Meal.swift in Sources */,

--- a/NyamNyam/NyamNyam/Screens/Home/ContentCarouselModule/Components/CarouselCell.swift
+++ b/NyamNyam/NyamNyam/Screens/Home/ContentCarouselModule/Components/CarouselCell.swift
@@ -1,0 +1,51 @@
+//
+//  CarouselCell.swift
+//  NyamNyam
+//
+//  Created by Noah Park on 2023/03/09.
+//
+
+import UIKit
+import SnapKit
+
+final class CarouselCell: UICollectionViewCell {
+    
+    static let cellId = "contentCell"
+    
+    private let scrollView = UIScrollView()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setContentViewLayout()
+        setScrollViewLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        self.prepare()
+    }
+    
+    func prepare() {
+        
+    }
+    
+    private func setContentViewLayout() {
+        contentView.snp.makeConstraints { make in
+            make.top.bottom.leading.trailing.equalToSuperview()
+        }
+    }
+    
+    private func setScrollViewLayout() {
+        contentView.addSubview(scrollView)
+        scrollView.snp.makeConstraints { make in
+            make.top.bottom.equalToSuperview()
+            make.leading.trailing.equalToSuperview()
+        }
+        scrollView.backgroundColor = .blue
+    }
+    
+}

--- a/NyamNyam/NyamNyam/Screens/Home/ContentCarouselModule/ContentCarouselModuleViewController.swift
+++ b/NyamNyam/NyamNyam/Screens/Home/ContentCarouselModule/ContentCarouselModuleViewController.swift
@@ -6,10 +6,40 @@
 //
 
 import UIKit
+import SnapKit
 
 final class ContentCarouselModuleViewController: UIViewController {
-
+    
     let viewModel: HomeViewModel
+    
+    private lazy var collectionViewFlowLayout: UICollectionViewFlowLayout = {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .horizontal
+        layout.itemSize = CGSize(width: view.frame.width - 60,
+                                 height: view.frame.height)
+        layout.minimumLineSpacing = 15.0
+        layout.minimumInteritemSpacing = 0
+        return layout
+    }()
+    
+    lazy var collectionView: UICollectionView = {
+        guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+        else { fatalError() }
+        let insetX = (scene.screen.bounds.width - collectionViewFlowLayout.itemSize.width) / 2.0
+        let view = UICollectionView(frame: .zero, collectionViewLayout: self.collectionViewFlowLayout)
+        view.isScrollEnabled = true
+        view.showsHorizontalScrollIndicator = false
+        view.showsVerticalScrollIndicator = true
+        view.backgroundColor = .clear
+        view.clipsToBounds = true
+        view.register(CarouselCell.self, forCellWithReuseIdentifier: CarouselCell.cellId)
+        view.isPagingEnabled = false
+        view.contentInsetAdjustmentBehavior = .never
+        view.contentInset = UIEdgeInsets(top: 0, left: insetX, bottom: 0, right: insetX)
+        view.decelerationRate = .fast
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
     
     init(viewModel: HomeViewModel) {
         self.viewModel = viewModel
@@ -22,7 +52,36 @@ final class ContentCarouselModuleViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .green
+        setCollectionViewLayout()
+        
+        bind(to: viewModel)
+    }
+    
+    private func bind(to viewModel: HomeViewModel) {
+        viewModel.currentCampus.observe(on: self) { _ in
+            
+        }
+        
+        viewModel.indexOfDate.observe(on: self) { _ in
+            
+        }
+        viewModel.indexOfCafeteria.observe(on: self) { [weak self] index in
+            self?.scrollViewBy(buttonIndex: index)
+        }
+    }
+    
+    
+}
+
+extension ContentCarouselModuleViewController {
+    private func setCollectionViewLayout() {
+        collectionView.delegate = self
+        collectionView.dataSource = self
+        collectionView.register(CarouselCell.self, forCellWithReuseIdentifier: CarouselCell.cellId)
+        view.addSubview(collectionView)
+        collectionView.snp.makeConstraints { make in
+            make.leading.trailing.top.bottom.equalToSuperview()
+        }
     }
 }
 
@@ -30,12 +89,34 @@ final class ContentCarouselModuleViewController: UIViewController {
 // MARK: DataSource
 extension ContentCarouselModuleViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 10
+        return viewModel.currentCampus.value == .seoul ? viewModel.seoulCafeteriaList.count : viewModel.ansungCafeteriaList.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        return UICollectionViewCell()
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CarouselCell.cellId, for: indexPath) as! CarouselCell
+        return cell
+    }
+}
+
+extension ContentCarouselModuleViewController: UICollectionViewDelegate {
+    
+}
+
+extension ContentCarouselModuleViewController: UICollectionViewDelegateFlowLayout {
+    func scrollViewWillEndDragging(
+        _ scrollView: UIScrollView,
+        withVelocity velocity: CGPoint,
+        targetContentOffset: UnsafeMutablePointer<CGPoint>
+    ) {
+        let scrolledOffsetX = targetContentOffset.pointee.x + scrollView.contentInset.left
+        let cellWidth = collectionViewFlowLayout.itemSize.width + collectionViewFlowLayout.minimumLineSpacing
+        viewModel.indexOfCafeteria.value = Int(round(scrolledOffsetX / cellWidth))
+        let index = viewModel.indexOfCafeteria.value
+        targetContentOffset.pointee = CGPoint(x: CGFloat(index) * cellWidth - scrollView.contentInset.left, y: scrollView.contentInset.top)
     }
     
-  
+    func scrollViewBy(buttonIndex: Int) {
+        let indexPath = IndexPath(item: buttonIndex, section: 0)
+        self.collectionView.scrollToItem(at: indexPath, at: [.centeredVertically, .centeredHorizontally], animated: true)
+    }
 }

--- a/NyamNyam/NyamNyam/Screens/Home/ContentCarouselModule/ContentCarouselModuleViewController.swift
+++ b/NyamNyam/NyamNyam/Screens/Home/ContentCarouselModule/ContentCarouselModuleViewController.swift
@@ -1,0 +1,41 @@
+//
+//  ContentCarouselModuleViewController.swift
+//  NyamNyam
+//
+//  Created by Noah Park on 2023/03/08.
+//
+
+import UIKit
+
+final class ContentCarouselModuleViewController: UIViewController {
+
+    let viewModel: HomeViewModel
+    
+    init(viewModel: HomeViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .green
+    }
+}
+
+
+// MARK: DataSource
+extension ContentCarouselModuleViewController: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return 10
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        return UICollectionViewCell()
+    }
+    
+  
+}

--- a/NyamNyam/NyamNyam/Screens/Home/HomeViewController.swift
+++ b/NyamNyam/NyamNyam/Screens/Home/HomeViewController.swift
@@ -10,7 +10,8 @@ import SnapKit
 
 final class HomeViewController: UIViewController {
     let viewModel = HomeViewModel()
-    lazy var OptionSelectModule = OptionSelectModuleViewController(viewModel: viewModel)
+    lazy var optionSelectModule = OptionSelectModuleViewController(viewModel: viewModel)
+    lazy var contentCarouselModule = ContentCarouselModuleViewController(viewModel: viewModel)
     
     override var preferredStatusBarStyle: UIStatusBarStyle {
         if #available(iOS 13, *) {
@@ -25,19 +26,29 @@ final class HomeViewController: UIViewController {
         navigationController?.setNavigationBarHidden(true, animated: true)
         view.backgroundColor = .white
         setOptionSelectModuleLayout()
+        setContentCarouselModuleLayout()
     }
 }
 
 extension HomeViewController {
-    
+    private func setContentCarouselModuleLayout() {
+        self.addChild(contentCarouselModule)
+        self.view.addSubview(contentCarouselModule.view)
+        contentCarouselModule.didMove(toParent: self)
+        contentCarouselModule.view.snp.makeConstraints { make in
+            make.top.equalTo(optionSelectModule.view
+                .snp.bottom)
+            make.leading.trailing.bottom.equalToSuperview()
+        }
+    }
 }
 
 extension HomeViewController {
     private func setOptionSelectModuleLayout() {
-        self.addChild(OptionSelectModule)
-        self.view.addSubview(OptionSelectModule.view)
-        OptionSelectModule.didMove(toParent: self)
-        OptionSelectModule.view.snp.makeConstraints { make in
+        self.addChild(optionSelectModule)
+        self.view.addSubview(optionSelectModule.view)
+        optionSelectModule.didMove(toParent: self)
+        optionSelectModule.view.snp.makeConstraints { make in
             make.top.equalTo(view.snp.top).offset(63)
             make.leading.equalToSuperview()
             make.trailing.equalToSuperview()


### PR DESCRIPTION
### CollectionView로 캐러셀을 만들었습니다.

close #19 

# 개요

학식의 정보를 넘기는 캐러셀로 보여주기 때문에, 밑바탕이 될 가장 기본적인 형태의 캐러셀을 만들었습니다.

<img width="271" alt="스크린샷 2023-03-09 오후 5 25 52" src="https://user-images.githubusercontent.com/53016167/223963464-a38e8513-a7fb-4e35-b544-e4514b161f33.gif">

<br><br>

# UI

CollectionView와 CollectionViewFlowLayout을 이용해서 만들었습니다.

```swift
    private lazy var collectionViewFlowLayout: UICollectionViewFlowLayout = {
        let layout = UICollectionViewFlowLayout()
        layout.scrollDirection = .horizontal
        layout.itemSize = CGSize(width: view.frame.width - 60,
                                 height: view.frame.height)
        layout.minimumLineSpacing = 15.0
        layout.minimumInteritemSpacing = 0
        return layout
    }()
```

ItemSize width가 `ViewWidth - 60`인 이유는 양 옆 view가 보일 영역 15, 뷰와 뷰 사이의 간격 15, 총 30을 왼쪽 오른쪽만큼 빼주어야 하기 때문입니다.

<br><br>

# 로직

`버튼을 눌렀을 때 캐러셀의 변화`와 `캐러셀을 움직였을 때 버튼의 변화` 모두 viewModel의 indexOfCafeteria를 Observe하여 변화하게 됩니다.

<br>

## 캐러셀 드래그 -> 버튼 변화

해당 코드는 [스크롤 영역을 암시해주는 Carousel 구현 방법](https://ios-development.tistory.com/1020)을 참조했습니다.

```swift
    func scrollViewWillEndDragging(
        _ scrollView: UIScrollView,
        withVelocity velocity: CGPoint,
        targetContentOffset: UnsafeMutablePointer<CGPoint>
    ) {
        let scrolledOffsetX = targetContentOffset.pointee.x + scrollView.contentInset.left
        let cellWidth = collectionViewFlowLayout.itemSize.width + collectionViewFlowLayout.minimumLineSpacing
        viewModel.indexOfCafeteria.value = Int(round(scrolledOffsetX / cellWidth))
        let index = viewModel.indexOfCafeteria.value
        targetContentOffset.pointee = CGPoint(x: CGFloat(index) * cellWidth - scrollView.contentInset.left, y: scrollView.contentInset.top)
    }
    }
```

해당 로직은 맨 마지막 세줄을 자세히 보시면 되는데, 

먼저 ` Int(round(scrolledOffsetX / cellWidth))`는 스크롤offse을 cell width로 나눈 값, 즉 터치가 끝난 지점의 cell의 width와 비교해서 N + 0.0 ~ N + 1.0으로 수치화해서 0.5를 넘으면 N + 1, 넘지 않으면 N으로 계산해주는 코드입니다.
여기서 N은 cell의 개수입니다.

예를 들어 터치가 끝난 지점이 3.3이면 3으로 4.8이면 5로 계산하는 것이죠.
그럼 전자는 3번째 인덱스인 것이고 후자는 5번째 인덱스입니다.

마지막 줄은 그래서 결국 `targetContentOffset.pointee`를 바꿔주는 것입니다. 스크롤을 자동으로 땡겨주는 것이죠.
아까 3.3이면 3번째 처음으로, 4.8이면 5번째 cell의 처음으로 옮겨주는 것입니다.

이렇게 해서 다음과 같이 캐러셀이 작동하게 됩니다.

<img width="271" alt="스크린샷 2023-03-09 오후 5 25 52" src="https://user-images.githubusercontent.com/53016167/223968094-69a42ba8-78a2-4e48-9c34-18c7fa10ff5b.gif">

<br>

그리고 보셨듯이 `viewModel.indexOfCafeteria.value = Int(round(scrolledOffsetX / cellWidth))`에서 viewModel의 `indexOfCafeteria`의 값을 새로운 인덱스로 바꿔주게 되는데,
이렇게 값이 바뀌게 되면 `OptionSelectModuleViewController`에서도 바인딩 되어 있기 때문에 자동으로 버튼 선택 애니메이션도 일어나게 됩니다.

<br>

## 버튼 클릭 -> 캐러셀 변화

버튼이 클릭되면 `OptionSelectModuleViewController`에서 viewModel의 `indexOfCafeteria`의 값을 바꿔주게 됩니다.
그렇게 됐을 때 동작이 작동하도록 마찬가지로 `ContentCarouselModuleViewController`에서도 bind를 해주었습니다.

```swift
    private func bind(to viewModel: HomeViewModel) {

        ...

        viewModel.indexOfCafeteria.observe(on: self) { [weak self] index in
            self?.scrollViewBy(buttonIndex: index)
        }
    }
```
index 값의 변화는 `scrollViewBy(buttonIndex: Int)`를 트리거 하는데, 이는 collectionView에서 제공하는 scrollToItem을 트리거하게 됩니다.

해당 아이템(Cell)을 화면 가운데로 두는 작업을 일으키는 것이죠.

```swift
    func scrollViewBy(buttonIndex: Int) {
        let indexPath = IndexPath(item: buttonIndex, section: 0)
        self.collectionView.scrollToItem(at: indexPath, at: [.centeredVertically, .centeredHorizontally], animated: true)
    }
```


<br><br>



# Ref.
[스크롤 영역을 암시해주는 Carousel 구현 방법](https://ios-development.tistory.com/1020) - 김종권의 iOS앱 개발 알아가기
