### PR TITLE
Meal 모델에 파싱될 정제함수를 수정하였습니다

### DIFF
--- a/NyamNyam/NyamNyam/Global/Manager/DataManager.swift
+++ b/NyamNyam/NyamNyam/Global/Manager/DataManager.swift
@@ -42,7 +42,7 @@ final class DataManager {
                                            let menu = menuDict["menu"] as? String,
                                            let price = menuDict["price"] as? String {
                                             //TODO: 따로 status 검사하는 함수 넣어 변경 예정
-                                            meals.append(Meal(mealTime: getMealTime(mealTime), type: getMealType(mealType), cafeteria: getCafeteria(cafeteria), price: getPrice(price), menu: getMenu(menu), date: Calendar.current.date(bySettingHour: 9, minute: 0, second: 0, of: day.formatStringToDate() ?? Date()) ?? Date(), status: .normal))
+                                            meals.append(Meal(mealTime: getMealTime(mealTime), type: getMealType(mealType, campus), cafeteria: getCafeteria(cafeteria), price: getPrice(price), menu: getMenu(menu), date: Calendar.current.date(bySettingHour: 9, minute: 0, second: 0, of: day.formatStringToDate() ?? Date()) ?? Date(), status: .normal))
                                         }
                                     }
                                 }
@@ -86,9 +86,10 @@ private extension DataManager {
         }
     }
 
-    func getMealType(_ mealType: String) -> MealType {
-        switch mealType {
-        case "중식(특식)":
+    func getMealType(_ mealType: String, _ campus: String) -> MealType {
+        let mealTypeTuple = (mealType, campus)
+        switch mealTypeTuple {
+        case ("중식(특식)", "0"):
             return .special
         default:
             return .normal

--- a/NyamNyam/NyamNyam/Global/Manager/DataManager.swift
+++ b/NyamNyam/NyamNyam/Global/Manager/DataManager.swift
@@ -42,7 +42,7 @@ final class DataManager {
                                            let menu = menuDict["menu"] as? String,
                                            let price = menuDict["price"] as? String {
                                             //TODO: 따로 status 검사하는 함수 넣어 변경 예정
-                                            meals.append(Meal(mealTime: getMealTime(mealTime), type: getMealType(mealType, campus), cafeteria: getCafeteria(cafeteria), price: getPrice(price), menu: getMenu(menu), date: Calendar.current.date(bySettingHour: 9, minute: 0, second: 0, of: day.formatStringToDate() ?? Date()) ?? Date(), status: .normal))
+                                            meals.append(Meal(mealTime: getMealTime(mealTime), type: getMealType(mealType, campus), cafeteria: getCafeteria(cafeteria), price: getPrice(price), menu: getMenu(menu), date: Calendar.current.date(bySettingHour: 9, minute: 0, second: 0, of: day.formatStringToDate() ?? Date()) ?? Date(), status: getStatus(menu)))
                                         }
                                     }
                                 }
@@ -126,6 +126,15 @@ private extension DataManager {
 
     func getMenu(_ menu: String) -> [String] {
         return menu.components(separatedBy: "|")
+    }
+    
+    func getStatus(_ menu: String) -> Status {
+        switch menu {
+        case "주말운영없음":
+            return .CloseOnWeekends
+        default :
+            return .normal
+        }
     }
 }
 

--- a/NyamNyam/NyamNyam/Global/Manager/DataManager.swift
+++ b/NyamNyam/NyamNyam/Global/Manager/DataManager.swift
@@ -61,11 +61,13 @@ final class DataManager {
         for dayIndex in weeklyDate.indices {
             var meals: Set<Meal> = []
             for meal in mealsForDay {
-                if weeklyDate[dayIndex] == meal.date {
+                if weeklyDate[dayIndex] == meal.date && meal.menu != [""] {
                     meals.insert(meal)
                 }
             }
-            mealsForWeek.append(MealsForDay(date: weeklyDate[dayIndex], meals: meals))
+            if meals != [] {
+                mealsForWeek.append(MealsForDay(date: weeklyDate[dayIndex], meals: meals))
+            }
         }
         return mealsForWeek
     }


### PR DESCRIPTION
## Meal 모델에 파싱될 정제함수를 수정하였습니다.
Close #15 

### 전달되는 식단에서 예외처리를 해야할 부분이 크게 두가지 있습니다.
1. 주말에 운영을 안하는 경우
2. 식단이 아직 중앙대 포탈에 업로드가 되지 않은 경우

이 두가지 부분을 식별할 수 있도록 DataManager를 수정하였습니다.
1. 주말에 운영을 안하는 경우
주말에 운영이 없는 데이터의 경우에 
<img width="271" alt="image" src="https://user-images.githubusercontent.com/103012087/224104644-388af01e-8628-43f9-9d99-26457789cfef.png">
위의 이미지 처럼 데이터가 들어오게 됩니다.

따라서 기존에 `Meal` 모델에 추가해 두었던 `Status`를 

```swift
    func getStatus(_ menu: String) -> Status {
        switch menu {
        case "주말운영없음":
            return .CloseOnWeekends
        default :
            return .normal
        }
    }
```

위와 같은 함수로 `menu`의 값에 따라 "주말운영없음"의 경우에는 `.CloseOnWeekends`를 반환하도록 하였습니다.
`status`에 따라서 분기처리를 해주시면 될 것 같습니다.
> 여기서 <Set> 은 중복데이터를 기본적으로 취급하지 않기때문에 "주말운영없음"의 경우 하나의 데이터만 들어가게 됩니다. 따라서 `cafeteria`와 `status`를 기준으로 한 예외처리를 해주시면 될 것 같습니다.
한가지 걸리는 부분은 **서울캠의 참슬기식당의 중식(특식)**의 경우에는 참슬기 식당의 두가지가 생기게 됩니다.
이는 `mealType`이 각각 `.normal`, `.special` 두개로 갈라지기 때문인데 한가지만 반영하셔서 진행하시면 될 것 같습니다 !

2. 식단이 아직 중앙대 포탈에 업로드 되지 않은 경우
이 경우 기존에는 날짜만 들어간 빈 배열이 `[MealsForDay]`에 들어갔습니다.
그러나 해당 날짜의 데이터를 확인하는 것보다 데이터가 없는 날짜를 UI 부분에서 예외처리만 하는 것이 더욱 간단하므로 `[MealsForDay]`를 구성하는 과정에서 추가되지 않도록 수정하였습니다.
수정된 코드는 아래와 같습니다.

```swift 
            for meal in mealsForDay {
                if weeklyDate[dayIndex] == meal.date && meal.menu != [""] {
                    meals.insert(meal)
                }
            }
            if meals != [] {
                mealsForWeek.append(MealsForDay(date: weeklyDate[dayIndex], meals: meals))
            }
```

`getMealsForWeeks()` 함수의 일부분에서 데이터가 없는 경우 `meal.menu`를 검사하여 `meals`에 추가하는 작업을 진행하지 않습니다.

이후 `meals`를 검사하여 빈 배열이 아닌 경우 (menu 데이터가 있는 경우)에만 `[MealsForDay]` 에 추가하도록 하였습니다.

### + 추가 변경 사항
- 시간대가 다른 mealType을 식별하기 위한 함수를 수정하였습니다

```swift
    func getMealType(_ mealType: String, _ campus: String) -> MealType {
        let mealTypeTuple = (mealType, campus)
        switch mealTypeTuple {
        case ("중식(특식)", "0"):
            return .special
        default:
            return .normal
        }
    }
```

수정한 이유는 안성캠퍼스에도 `"중식(특식)"` 이라는 `MealType`이 존재하기 때문입니다.
따라서 튜플을 이용하여 `mealType`과 `campus`의 튜플을 만들고 `"중식(특식)", "서울캠"` 인 경우에만 `.special`을 반환하도록 수정하였습니다.