### PR TITLE
생활관B의 contentView를 업데이트하였습니다.

### DIFF
--- a/NyamNyam/NyamNyam/Screens/Home/ContentCarouselModule/Components/ContentStackView.swift
+++ b/NyamNyam/NyamNyam/Screens/Home/ContentCarouselModule/Components/ContentStackView.swift
@@ -42,16 +42,18 @@ final class ContentStackView: UIView {
     
     private func setStackViewContents() {
         guard let data = data else { return }
-        for row in 0..<(data.menu.count / 2) {
+        var colCount = 2
+        if data.cafeteria == .blueMirB { colCount = 1 }
+        for row in 0..<(data.menu.count / colCount) {
             let rowStackView = UIStackView()
             rowStackView.axis = .horizontal
             rowStackView.alignment = .fill
             rowStackView.distribution = .fillEqually
             rowStackView.spacing = 8
             
-            for col in 0..<2 {
+            for col in 0..<colCount {
                 let label = UILabel()
-                label.text = "\(data.menu[row * 2 + col])"
+                label.text = "\(data.menu[row * colCount + col])"
                 label.textAlignment = .left
                 label.textColor = .black
                 label.font = .systemFont(ofSize: 16, weight: .semibold)


### PR DESCRIPTION
close #39 

## 개요

왼쪽과 같은 상태에서 오른쪽으로 수정하였습니다.

<p>

<img width="283"  src="https://user-images.githubusercontent.com/53016167/224635484-a2d1436c-c106-4e91-ab48-b9b57264bac6.png">

<img width="283"  src="https://user-images.githubusercontent.com/53016167/224640134-3bc0bef0-8042-413f-98df-8351fe7c3f76.png">

</p>

<br><br>


## 로직 설명

기존에는 `colCount`가 항상 2였지만, `.blueMirB`일 경우에는 1로 수정해주었습니다.

```swift
    private func setStackViewContents() {
        guard let data = data else { return }
        var colCount = 2
        if data.cafeteria == .blueMirB { colCount = 1 }
        for row in 0..<(data.menu.count / colCount) {
            let rowStackView = UIStackView()
            rowStackView.axis = .horizontal
            rowStackView.alignment = .fill
            rowStackView.distribution = .fillEqually
            rowStackView.spacing = 8
            
            for col in 0..<colCount {
                let label = UILabel()
                label.text = "\(data.menu[row * colCount + col])"
                label.textAlignment = .left
                label.textColor = .black
                label.font = .systemFont(ofSize: 16, weight: .semibold)
                rowStackView.addArrangedSubview(label)
            }
            
            stackView.addArrangedSubview(rowStackView)
        }
    }
```

