### PR TITLE
SettingView의 카페테리아 순서를 변경하는 섹션을 구현합니다

### DIFF
--- a/NyamNyam/NyamNyam.xcodeproj/project.pbxproj
+++ b/NyamNyam/NyamNyam.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		2A429D9B29BE12F50044A3E6 /* SettingWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A429D9A29BE12F50044A3E6 /* SettingWebViewController.swift */; };
 		2A429D9E29BEBE030044A3E6 /* SetCafeteriaOrderTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A429D9D29BEBE030044A3E6 /* SetCafeteriaOrderTableView.swift */; };
 		2A429DA029BEBE1B0044A3E6 /* SetCafeteriaOrderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A429D9F29BEBE1B0044A3E6 /* SetCafeteriaOrderTableViewCell.swift */; };
+		2A429DA329BF36C50044A3E6 /* SetCafeteriaOrderTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A429DA229BF36C50044A3E6 /* SetCafeteriaOrderTitleView.swift */; };
 		AB2D2C0129B8271C0015CB10 /* CafeteriaSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2D2C0029B8271C0015CB10 /* CafeteriaSelectView.swift */; };
 		AB2FDAAE29B84CC7001746DB /* CafeteriaButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2FDAAD29B84CC7001746DB /* CafeteriaButton.swift */; };
 		AB2FDAB229B8D4B4001746DB /* ContentCarouselModuleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2FDAB129B8D4B4001746DB /* ContentCarouselModuleViewController.swift */; };
@@ -74,6 +75,7 @@
 		2A429D9A29BE12F50044A3E6 /* SettingWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingWebViewController.swift; sourceTree = "<group>"; };
 		2A429D9D29BEBE030044A3E6 /* SetCafeteriaOrderTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetCafeteriaOrderTableView.swift; sourceTree = "<group>"; };
 		2A429D9F29BEBE1B0044A3E6 /* SetCafeteriaOrderTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetCafeteriaOrderTableViewCell.swift; sourceTree = "<group>"; };
+		2A429DA229BF36C50044A3E6 /* SetCafeteriaOrderTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetCafeteriaOrderTitleView.swift; sourceTree = "<group>"; };
 		AB2D2C0029B8271C0015CB10 /* CafeteriaSelectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CafeteriaSelectView.swift; sourceTree = "<group>"; };
 		AB2FDAAD29B84CC7001746DB /* CafeteriaButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CafeteriaButton.swift; sourceTree = "<group>"; };
 		AB2FDAB129B8D4B4001746DB /* ContentCarouselModuleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCarouselModuleViewController.swift; sourceTree = "<group>"; };
@@ -194,6 +196,7 @@
 			isa = PBXGroup;
 			children = (
 				2A429D9F29BEBE1B0044A3E6 /* SetCafeteriaOrderTableViewCell.swift */,
+				2A429DA229BF36C50044A3E6 /* SetCafeteriaOrderTitleView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -535,6 +538,7 @@
 				ABBDF69329BA328A00E9347A /* ExpandableMealCardView.swift in Sources */,
 				2A429D9229BDDA0B0044A3E6 /* SettingViewController.swift in Sources */,
 				2A429DA029BEBE1B0044A3E6 /* SetCafeteriaOrderTableViewCell.swift in Sources */,
+				2A429DA329BF36C50044A3E6 /* SetCafeteriaOrderTitleView.swift in Sources */,
 				ABEAFBCF29AC9ED3002C3119 /* HomeViewController.swift in Sources */,
 				ABEAFC1F29AE6769002C3119 /* UserDefaults+.swift in Sources */,
 				2A429D9E29BEBE030044A3E6 /* SetCafeteriaOrderTableView.swift in Sources */,

--- a/NyamNyam/NyamNyam.xcodeproj/project.pbxproj
+++ b/NyamNyam/NyamNyam.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		2A429D9529BDDB370044A3E6 /* SettingListTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A429D9429BDDB370044A3E6 /* SettingListTableViewController.swift */; };
 		2A429D9929BDE2A40044A3E6 /* SettingListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A429D9829BDE2A40044A3E6 /* SettingListTableViewCell.swift */; };
 		2A429D9B29BE12F50044A3E6 /* SettingWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A429D9A29BE12F50044A3E6 /* SettingWebViewController.swift */; };
+		2A429D9E29BEBE030044A3E6 /* SetCafeteriaOrderTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A429D9D29BEBE030044A3E6 /* SetCafeteriaOrderTableView.swift */; };
+		2A429DA029BEBE1B0044A3E6 /* SetCafeteriaOrderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A429D9F29BEBE1B0044A3E6 /* SetCafeteriaOrderTableViewCell.swift */; };
 		AB2D2C0129B8271C0015CB10 /* CafeteriaSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2D2C0029B8271C0015CB10 /* CafeteriaSelectView.swift */; };
 		AB2FDAAE29B84CC7001746DB /* CafeteriaButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2FDAAD29B84CC7001746DB /* CafeteriaButton.swift */; };
 		AB2FDAB229B8D4B4001746DB /* ContentCarouselModuleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2FDAB129B8D4B4001746DB /* ContentCarouselModuleViewController.swift */; };
@@ -70,6 +72,8 @@
 		2A429D9429BDDB370044A3E6 /* SettingListTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingListTableViewController.swift; sourceTree = "<group>"; };
 		2A429D9829BDE2A40044A3E6 /* SettingListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingListTableViewCell.swift; sourceTree = "<group>"; };
 		2A429D9A29BE12F50044A3E6 /* SettingWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingWebViewController.swift; sourceTree = "<group>"; };
+		2A429D9D29BEBE030044A3E6 /* SetCafeteriaOrderTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetCafeteriaOrderTableView.swift; sourceTree = "<group>"; };
+		2A429D9F29BEBE1B0044A3E6 /* SetCafeteriaOrderTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetCafeteriaOrderTableViewCell.swift; sourceTree = "<group>"; };
 		AB2D2C0029B8271C0015CB10 /* CafeteriaSelectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CafeteriaSelectView.swift; sourceTree = "<group>"; };
 		AB2FDAAD29B84CC7001746DB /* CafeteriaButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CafeteriaButton.swift; sourceTree = "<group>"; };
 		AB2FDAB129B8D4B4001746DB /* ContentCarouselModuleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCarouselModuleViewController.swift; sourceTree = "<group>"; };
@@ -153,6 +157,7 @@
 		2A429D9329BDDA480044A3E6 /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				2A429D9C29BEBD910044A3E6 /* SetCafeteriaOrderModule */,
 				2A429D9629BDE2530044A3E6 /* SettingListViewModule */,
 			);
 			path = Components;
@@ -172,6 +177,23 @@
 			children = (
 				2A429D9829BDE2A40044A3E6 /* SettingListTableViewCell.swift */,
 				2A429D9A29BE12F50044A3E6 /* SettingWebViewController.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		2A429D9C29BEBD910044A3E6 /* SetCafeteriaOrderModule */ = {
+			isa = PBXGroup;
+			children = (
+				2A429DA129BEBE7D0044A3E6 /* Components */,
+				2A429D9D29BEBE030044A3E6 /* SetCafeteriaOrderTableView.swift */,
+			);
+			path = SetCafeteriaOrderModule;
+			sourceTree = "<group>";
+		};
+		2A429DA129BEBE7D0044A3E6 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				2A429D9F29BEBE1B0044A3E6 /* SetCafeteriaOrderTableViewCell.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -512,8 +534,10 @@
 				ABEAFC0129ACA0E4002C3119 /* MealsForDay.swift in Sources */,
 				ABBDF69329BA328A00E9347A /* ExpandableMealCardView.swift in Sources */,
 				2A429D9229BDDA0B0044A3E6 /* SettingViewController.swift in Sources */,
+				2A429DA029BEBE1B0044A3E6 /* SetCafeteriaOrderTableViewCell.swift in Sources */,
 				ABEAFBCF29AC9ED3002C3119 /* HomeViewController.swift in Sources */,
 				ABEAFC1F29AE6769002C3119 /* UserDefaults+.swift in Sources */,
+				2A429D9E29BEBE030044A3E6 /* SetCafeteriaOrderTableView.swift in Sources */,
 				2A429D9929BDE2A40044A3E6 /* SettingListTableViewCell.swift in Sources */,
 				ABEAFC0429ACA4B1002C3119 /* Date+.swift in Sources */,
 				ABEAFC0D29ACA59E002C3119 /* HomeViewModel.swift in Sources */,

--- a/NyamNyam/NyamNyam.xcodeproj/project.pbxproj
+++ b/NyamNyam/NyamNyam.xcodeproj/project.pbxproj
@@ -14,7 +14,7 @@
 		2A429D9529BDDB370044A3E6 /* SettingListTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A429D9429BDDB370044A3E6 /* SettingListTableViewController.swift */; };
 		2A429D9929BDE2A40044A3E6 /* SettingListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A429D9829BDE2A40044A3E6 /* SettingListTableViewCell.swift */; };
 		2A429D9B29BE12F50044A3E6 /* SettingWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A429D9A29BE12F50044A3E6 /* SettingWebViewController.swift */; };
-		2A429D9E29BEBE030044A3E6 /* SetCafeteriaOrderTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A429D9D29BEBE030044A3E6 /* SetCafeteriaOrderTableView.swift */; };
+		2A429D9E29BEBE030044A3E6 /* SetCafeteriaOrderTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A429D9D29BEBE030044A3E6 /* SetCafeteriaOrderTableViewController.swift */; };
 		2A429DA029BEBE1B0044A3E6 /* SetCafeteriaOrderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A429D9F29BEBE1B0044A3E6 /* SetCafeteriaOrderTableViewCell.swift */; };
 		2A429DA329BF36C50044A3E6 /* SetCafeteriaOrderTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A429DA229BF36C50044A3E6 /* SetCafeteriaOrderTitleView.swift */; };
 		AB2D2C0129B8271C0015CB10 /* CafeteriaSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2D2C0029B8271C0015CB10 /* CafeteriaSelectView.swift */; };
@@ -73,7 +73,7 @@
 		2A429D9429BDDB370044A3E6 /* SettingListTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingListTableViewController.swift; sourceTree = "<group>"; };
 		2A429D9829BDE2A40044A3E6 /* SettingListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingListTableViewCell.swift; sourceTree = "<group>"; };
 		2A429D9A29BE12F50044A3E6 /* SettingWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingWebViewController.swift; sourceTree = "<group>"; };
-		2A429D9D29BEBE030044A3E6 /* SetCafeteriaOrderTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetCafeteriaOrderTableView.swift; sourceTree = "<group>"; };
+		2A429D9D29BEBE030044A3E6 /* SetCafeteriaOrderTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetCafeteriaOrderTableViewController.swift; sourceTree = "<group>"; };
 		2A429D9F29BEBE1B0044A3E6 /* SetCafeteriaOrderTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetCafeteriaOrderTableViewCell.swift; sourceTree = "<group>"; };
 		2A429DA229BF36C50044A3E6 /* SetCafeteriaOrderTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetCafeteriaOrderTitleView.swift; sourceTree = "<group>"; };
 		AB2D2C0029B8271C0015CB10 /* CafeteriaSelectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CafeteriaSelectView.swift; sourceTree = "<group>"; };
@@ -187,7 +187,7 @@
 			isa = PBXGroup;
 			children = (
 				2A429DA129BEBE7D0044A3E6 /* Components */,
-				2A429D9D29BEBE030044A3E6 /* SetCafeteriaOrderTableView.swift */,
+				2A429D9D29BEBE030044A3E6 /* SetCafeteriaOrderTableViewController.swift */,
 			);
 			path = SetCafeteriaOrderModule;
 			sourceTree = "<group>";
@@ -541,7 +541,7 @@
 				2A429DA329BF36C50044A3E6 /* SetCafeteriaOrderTitleView.swift in Sources */,
 				ABEAFBCF29AC9ED3002C3119 /* HomeViewController.swift in Sources */,
 				ABEAFC1F29AE6769002C3119 /* UserDefaults+.swift in Sources */,
-				2A429D9E29BEBE030044A3E6 /* SetCafeteriaOrderTableView.swift in Sources */,
+				2A429D9E29BEBE030044A3E6 /* SetCafeteriaOrderTableViewController.swift in Sources */,
 				2A429D9929BDE2A40044A3E6 /* SettingListTableViewCell.swift in Sources */,
 				ABEAFC0429ACA4B1002C3119 /* Date+.swift in Sources */,
 				ABEAFC0D29ACA59E002C3119 /* HomeViewModel.swift in Sources */,

--- a/NyamNyam/NyamNyam/Screens/Setting/Components/SetCafeteriaOrderModule/Components/SetCafeteriaOrderTableViewCell.swift
+++ b/NyamNyam/NyamNyam/Screens/Setting/Components/SetCafeteriaOrderModule/Components/SetCafeteriaOrderTableViewCell.swift
@@ -1,0 +1,73 @@
+//
+//  SetCafeteriaOrderTableViewCell.swift
+//  NyamNyam
+//
+//  Created by 한택환 on 2023/03/13.
+//
+
+import UIKit
+import SnapKit
+
+final class SetCafeteriaOrderTableViewCell: UITableViewCell {
+    
+    private let cafeteriaLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 16, weight: .semibold)
+        label.textColor = Pallete.gray.color
+        return label
+    }()
+    
+    private let switchCafeteriaImageView: UIImageView = {
+        let image = UIImageView(image: UIImage(systemName: "equal"))
+        image.tintColor = Pallete.gray50.color
+        return image
+    }()
+    
+    private let cafeteriaNumberImageView: UIImageView = {
+        let image = UIImageView()
+        image.tintColor = Pallete.gray.color
+        return image
+    }()
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        self.setupLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+    }
+}
+
+private extension SetCafeteriaOrderTableViewCell {
+    func setupLayout() {
+        self.addSubview(cafeteriaNumberImageView)
+        cafeteriaNumberImageView.snp.makeConstraints { make in
+            make.leading.equalToSuperview().offset(20)
+            make.centerY.equalToSuperview()
+        }
+        
+        self.addSubview(cafeteriaLabel)
+        cafeteriaLabel.snp.makeConstraints { make in
+            make.leading.equalTo(cafeteriaNumberImageView.snp.trailing).offset(17)
+            make.centerY.equalToSuperview()
+        }
+        
+        self.addSubview(switchCafeteriaImageView)
+        switchCafeteriaImageView.snp.makeConstraints { make in
+            make.trailing.equalToSuperview().offset(-16)
+            make.centerY.equalToSuperview()
+        }
+    }
+}
+
+extension SetCafeteriaOrderTableViewCell {
+    func configureUI(_ title: String, _ num: String) {
+        cafeteriaLabel.text = title
+        cafeteriaNumberImageView.image = UIImage(systemName: num)
+    }
+}

--- a/NyamNyam/NyamNyam/Screens/Setting/Components/SetCafeteriaOrderModule/Components/SetCafeteriaOrderTableViewCell.swift
+++ b/NyamNyam/NyamNyam/Screens/Setting/Components/SetCafeteriaOrderModule/Components/SetCafeteriaOrderTableViewCell.swift
@@ -10,6 +10,8 @@ import SnapKit
 
 final class SetCafeteriaOrderTableViewCell: UITableViewCell {
     
+    static let setCafeteriaOrderCellId = "setCafeteriaOrderCell"
+    
     private let cafeteriaLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 16, weight: .semibold)
@@ -23,7 +25,7 @@ final class SetCafeteriaOrderTableViewCell: UITableViewCell {
         return image
     }()
     
-    private let cafeteriaNumberImageView: UIImageView = {
+    let cafeteriaNumberImageView: UIImageView = {
         let image = UIImageView()
         image.tintColor = Pallete.gray.color
         return image
@@ -68,6 +70,6 @@ private extension SetCafeteriaOrderTableViewCell {
 extension SetCafeteriaOrderTableViewCell {
     func configureUI(_ title: String, _ num: String) {
         cafeteriaLabel.text = title
-        cafeteriaNumberImageView.image = UIImage(systemName: num)
+        cafeteriaNumberImageView.image = UIImage(systemName: "\(num).circle.fill")
     }
 }

--- a/NyamNyam/NyamNyam/Screens/Setting/Components/SetCafeteriaOrderModule/Components/SetCafeteriaOrderTitleView.swift
+++ b/NyamNyam/NyamNyam/Screens/Setting/Components/SetCafeteriaOrderModule/Components/SetCafeteriaOrderTitleView.swift
@@ -1,0 +1,54 @@
+//
+//  SetCafeteriaOrderTitleView.swift
+//  NyamNyam
+//
+//  Created by 한택환 on 2023/03/13.
+//
+
+import UIKit
+import SnapKit
+
+final class SetCafeteriaOrderTitleView: UIView {
+    private let title: UILabel = {
+        let label = UILabel()
+        label.text = "식당 순서 설정"
+        label.font = .systemFont(ofSize: 16, weight: .semibold)
+        label.textColor = .black
+        return label
+    }()
+    
+    private let subTitle: UILabel = {
+        let label = UILabel()
+        label.text = "설정한 순서는 자동으로 저장돼요"
+        label.font = .systemFont(ofSize: 12, weight: .semibold)
+        label.textColor = Pallete.gray50.color
+        return label
+    }()
+    
+    init() {
+        super.init(frame: .zero)
+        self.backgroundColor = .white
+        setupLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupLayout() {
+        self.addSubview(title)
+        title.snp.makeConstraints { make in
+            make.leading.equalToSuperview().offset(20)
+            make.centerY.equalToSuperview()
+            make.top.bottom.equalToSuperview()
+        }
+        
+        
+        self.addSubview(subTitle)
+        subTitle.snp.makeConstraints { make in
+            make.leading.equalTo(title.snp.trailing).offset(15)
+            make.centerY.equalToSuperview()
+            make.top.bottom.equalToSuperview()
+        }
+    }
+}

--- a/NyamNyam/NyamNyam/Screens/Setting/Components/SetCafeteriaOrderModule/SetCafeteriaOrderTableView.swift
+++ b/NyamNyam/NyamNyam/Screens/Setting/Components/SetCafeteriaOrderModule/SetCafeteriaOrderTableView.swift
@@ -5,11 +5,59 @@
 //  Created by 한택환 on 2023/03/13.
 //
 
-import Foundation
+import UIKit
+import SnapKit
 
 final class SetCafeteriaOrderTableView: UIViewController {
     
+    var seoulCafeteriaList: [String] = UserDefaults.standard.seoulCafeteria
+    var ansungCafeteriaList: [String] = UserDefaults.standard.ansungCafeteria
+    
+    lazy var tableView: UITableView = {
+        let tableView = UITableView(frame: .zero, style: .plain)
+        tableView.rowHeight = 40
+        return tableView
+    }()
+    
+    init() {
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
+        print(seoulCafeteriaList)
+        setTableViewLayout()
+    }
+}
+
+private extension SetCafeteriaOrderTableView {
+    func setTableViewLayout() {
+        tableView.register(SetCafeteriaOrderTableViewCell.self, forCellReuseIdentifier: SetCafeteriaOrderTableViewCell.setCafeteriaOrderCellId)
+        view.addSubview(tableView)
+        tableView.delegate = self
+        tableView.dataSource = self
+        tableView.separatorInset = UIEdgeInsets(top: 0, left: 50, bottom: 0, right: 0)
+        tableView.snp.makeConstraints { make in
+            make.top.leading.trailing.bottom.equalToSuperview()
+        }
+    }
+}
+
+extension SetCafeteriaOrderTableView: UITableViewDelegate {
+}
+
+extension SetCafeteriaOrderTableView: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return seoulCafeteriaList.count
+    }
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: SetCafeteriaOrderTableViewCell.setCafeteriaOrderCellId) as? SetCafeteriaOrderTableViewCell else { return UITableViewCell() }
+        cell.configureUI(seoulCafeteriaList[indexPath.row], String(indexPath.row+1))
+        cell.backgroundColor = .white
+        return cell
     }
 }

--- a/NyamNyam/NyamNyam/Screens/Setting/Components/SetCafeteriaOrderModule/SetCafeteriaOrderTableView.swift
+++ b/NyamNyam/NyamNyam/Screens/Setting/Components/SetCafeteriaOrderModule/SetCafeteriaOrderTableView.swift
@@ -40,6 +40,9 @@ private extension SetCafeteriaOrderTableView {
         view.addSubview(tableView)
         tableView.delegate = self
         tableView.dataSource = self
+        tableView.dragDelegate = self
+        tableView.dropDelegate = self
+        tableView.dragInteractionEnabled = true
         tableView.separatorInset = UIEdgeInsets(top: 0, left: 50, bottom: 0, right: 0)
         tableView.snp.makeConstraints { make in
             make.top.leading.trailing.bottom.equalToSuperview()
@@ -59,5 +62,34 @@ extension SetCafeteriaOrderTableView: UITableViewDataSource {
         cell.configureUI(seoulCafeteriaList[indexPath.row], String(indexPath.row+1))
         cell.backgroundColor = .white
         return cell
+    }
+    func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        return true
+    }
+    // Move Row Instance Method
+    internal func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
+        let moveCell = seoulCafeteriaList[sourceIndexPath.row]
+        seoulCafeteriaList.remove(at: sourceIndexPath.row)
+        seoulCafeteriaList.insert(moveCell, at: destinationIndexPath.row)
+        UserDefaults.standard.seoulCafeteria = seoulCafeteriaList
+        tableView.reloadData()
+    }
+}
+
+extension SetCafeteriaOrderTableView: UITableViewDragDelegate {
+    func tableView(_ tableView: UITableView, itemsForBeginning session: UIDragSession, at indexPath: IndexPath) -> [UIDragItem] {
+        return [UIDragItem(itemProvider: NSItemProvider())]
+    }
+}
+
+// MARK:- UITableView UITableViewDropDelegate
+extension SetCafeteriaOrderTableView: UITableViewDropDelegate {
+    func tableView(_ tableView: UITableView, dropSessionDidUpdate session: UIDropSession, withDestinationIndexPath destinationIndexPath: IndexPath?) -> UITableViewDropProposal {
+        if session.localDragSession != nil {
+            return UITableViewDropProposal(operation: .move, intent: .insertAtDestinationIndexPath)
+        }
+        return UITableViewDropProposal(operation: .cancel, intent: .unspecified)
+    }
+    func tableView(_ tableView: UITableView, performDropWith coordinator: UITableViewDropCoordinator) {
     }
 }

--- a/NyamNyam/NyamNyam/Screens/Setting/Components/SetCafeteriaOrderModule/SetCafeteriaOrderTableView.swift
+++ b/NyamNyam/NyamNyam/Screens/Setting/Components/SetCafeteriaOrderModule/SetCafeteriaOrderTableView.swift
@@ -1,0 +1,15 @@
+//
+//  SetCafeteriaOrderTableView.swift
+//  NyamNyam
+//
+//  Created by 한택환 on 2023/03/13.
+//
+
+import Foundation
+
+final class SetCafeteriaOrderTableView: UIViewController {
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/NyamNyam/NyamNyam/Screens/Setting/Components/SetCafeteriaOrderModule/SetCafeteriaOrderTableView.swift
+++ b/NyamNyam/NyamNyam/Screens/Setting/Components/SetCafeteriaOrderModule/SetCafeteriaOrderTableView.swift
@@ -13,6 +13,7 @@ final class SetCafeteriaOrderTableView: UIViewController {
     var seoulCafeteriaList: [String] = UserDefaults.standard.seoulCafeteria
     var ansungCafeteriaList: [String] = UserDefaults.standard.ansungCafeteria
     
+    let titleLabel: UIView = SetCafeteriaOrderTitleView()
     lazy var tableView: UITableView = {
         let tableView = UITableView(frame: .zero, style: .plain)
         tableView.rowHeight = 40
@@ -30,6 +31,8 @@ final class SetCafeteriaOrderTableView: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         print(seoulCafeteriaList)
+        view.backgroundColor = .white
+        setTitleLayout()
         setTableViewLayout()
     }
 }
@@ -45,7 +48,16 @@ private extension SetCafeteriaOrderTableView {
         tableView.dragInteractionEnabled = true
         tableView.separatorInset = UIEdgeInsets(top: 0, left: 50, bottom: 0, right: 0)
         tableView.snp.makeConstraints { make in
-            make.top.leading.trailing.bottom.equalToSuperview()
+            make.top.equalTo(titleLabel.snp.bottom).offset(25)
+            make.leading.trailing.bottom.equalToSuperview()
+        }
+    }
+    
+    func setTitleLayout() {
+        view.addSubview(titleLabel)
+        titleLabel.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(14)
+            make.leading.equalToSuperview()
         }
     }
 }

--- a/NyamNyam/NyamNyam/Screens/Setting/Components/SetCafeteriaOrderModule/SetCafeteriaOrderTableViewController.swift
+++ b/NyamNyam/NyamNyam/Screens/Setting/Components/SetCafeteriaOrderModule/SetCafeteriaOrderTableViewController.swift
@@ -1,5 +1,5 @@
 //
-//  SetCafeteriaOrderTableView.swift
+//  SetCafeteriaOrderTableViewController.swift
 //  NyamNyam
 //
 //  Created by 한택환 on 2023/03/13.
@@ -8,7 +8,7 @@
 import UIKit
 import SnapKit
 
-final class SetCafeteriaOrderTableView: UIViewController {
+final class SetCafeteriaOrderTableViewController: UIViewController {
     
     var seoulCafeteriaList: [String] = UserDefaults.standard.seoulCafeteria
     var ansungCafeteriaList: [String] = UserDefaults.standard.ansungCafeteria
@@ -37,7 +37,7 @@ final class SetCafeteriaOrderTableView: UIViewController {
     }
 }
 
-private extension SetCafeteriaOrderTableView {
+private extension SetCafeteriaOrderTableViewController {
     func setTableViewLayout() {
         tableView.register(SetCafeteriaOrderTableViewCell.self, forCellReuseIdentifier: SetCafeteriaOrderTableViewCell.setCafeteriaOrderCellId)
         view.addSubview(tableView)
@@ -62,10 +62,10 @@ private extension SetCafeteriaOrderTableView {
     }
 }
 
-extension SetCafeteriaOrderTableView: UITableViewDelegate {
+extension SetCafeteriaOrderTableViewController: UITableViewDelegate {
 }
 
-extension SetCafeteriaOrderTableView: UITableViewDataSource {
+extension SetCafeteriaOrderTableViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return seoulCafeteriaList.count
     }
@@ -88,14 +88,14 @@ extension SetCafeteriaOrderTableView: UITableViewDataSource {
     }
 }
 
-extension SetCafeteriaOrderTableView: UITableViewDragDelegate {
+extension SetCafeteriaOrderTableViewController: UITableViewDragDelegate {
     func tableView(_ tableView: UITableView, itemsForBeginning session: UIDragSession, at indexPath: IndexPath) -> [UIDragItem] {
         return [UIDragItem(itemProvider: NSItemProvider())]
     }
 }
 
 // MARK:- UITableView UITableViewDropDelegate
-extension SetCafeteriaOrderTableView: UITableViewDropDelegate {
+extension SetCafeteriaOrderTableViewController: UITableViewDropDelegate {
     func tableView(_ tableView: UITableView, dropSessionDidUpdate session: UIDropSession, withDestinationIndexPath destinationIndexPath: IndexPath?) -> UITableViewDropProposal {
         if session.localDragSession != nil {
             return UITableViewDropProposal(operation: .move, intent: .insertAtDestinationIndexPath)

--- a/NyamNyam/NyamNyam/Screens/Setting/Components/SetCafeteriaOrderModule/SetCafeteriaOrderTableViewController.swift
+++ b/NyamNyam/NyamNyam/Screens/Setting/Components/SetCafeteriaOrderModule/SetCafeteriaOrderTableViewController.swift
@@ -78,7 +78,6 @@ extension SetCafeteriaOrderTableViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
         return true
     }
-    // Move Row Instance Method
     internal func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
         let moveCell = seoulCafeteriaList[sourceIndexPath.row]
         seoulCafeteriaList.remove(at: sourceIndexPath.row)
@@ -94,7 +93,6 @@ extension SetCafeteriaOrderTableViewController: UITableViewDragDelegate {
     }
 }
 
-// MARK:- UITableView UITableViewDropDelegate
 extension SetCafeteriaOrderTableViewController: UITableViewDropDelegate {
     func tableView(_ tableView: UITableView, dropSessionDidUpdate session: UIDropSession, withDestinationIndexPath destinationIndexPath: IndexPath?) -> UITableViewDropProposal {
         if session.localDragSession != nil {

--- a/NyamNyam/NyamNyam/Screens/Setting/Components/SetCafeteriaOrderModule/SetCafeteriaOrderTableViewController.swift
+++ b/NyamNyam/NyamNyam/Screens/Setting/Components/SetCafeteriaOrderModule/SetCafeteriaOrderTableViewController.swift
@@ -101,14 +101,13 @@ extension SetCafeteriaOrderTableViewController: UITableViewDataSource {
         return true
     }
     func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
-        let moveCell = seoulCafeteriaList[sourceIndexPath.row]
+        let cell = seoulCafeteriaList[sourceIndexPath.row]
         seoulCafeteriaList.remove(at: sourceIndexPath.row)
-        seoulCafeteriaList.insert(moveCell, at: destinationIndexPath.row)
+        seoulCafeteriaList.insert(cell, at: destinationIndexPath.row)
         UserDefaults.standard.seoulCafeteria = seoulCafeteriaList.map({
             guard let cafeteria = Cafeteria(rawValue: $0.rawValue) else { fatalError() }
             return cafeteria.rawValue
         })
-        print(UserDefaults.standard.seoulCafeteria)
         tableView.reloadData()
     }
 }

--- a/NyamNyam/NyamNyam/Screens/Setting/Components/SetCafeteriaOrderModule/SetCafeteriaOrderTableViewController.swift
+++ b/NyamNyam/NyamNyam/Screens/Setting/Components/SetCafeteriaOrderModule/SetCafeteriaOrderTableViewController.swift
@@ -10,8 +10,30 @@ import SnapKit
 
 final class SetCafeteriaOrderTableViewController: UIViewController {
     
-    var seoulCafeteriaList: [String] = UserDefaults.standard.seoulCafeteria
-    var ansungCafeteriaList: [String] = UserDefaults.standard.ansungCafeteria
+    var seoulCafeteriaList: [Cafeteria] = [.chamseulgi, .blueMirA, .blueMirB, .student, .staff]
+    var ansungCafeteriaList: [Cafeteria] = [.cauEats, .cauBurger, .ramen]
+    
+    func getCafeteriaName(_ cafeteria: Cafeteria) -> String {
+        switch cafeteria {
+        case .chamseulgi:
+            return "참슬기"
+        case .blueMirA:
+            return "생활관A"
+        case .blueMirB:
+            return "생활관B"
+        case .student:
+            return "학생식당"
+        case .staff:
+            return "교직원"
+        case .cauEats:
+            return "카우이츠"
+        case .cauBurger:
+            return "카우버거"
+        case .ramen:
+            return "라면"
+        }
+    }
+
     
     let titleLabel: UIView = SetCafeteriaOrderTitleView()
     lazy var tableView: UITableView = {
@@ -71,18 +93,22 @@ extension SetCafeteriaOrderTableViewController: UITableViewDataSource {
     }
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: SetCafeteriaOrderTableViewCell.setCafeteriaOrderCellId) as? SetCafeteriaOrderTableViewCell else { return UITableViewCell() }
-        cell.configureUI(seoulCafeteriaList[indexPath.row], String(indexPath.row+1))
+        cell.configureUI(getCafeteriaName(seoulCafeteriaList[indexPath.row]), String(indexPath.row+1))
         cell.backgroundColor = .white
         return cell
     }
     func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
         return true
     }
-    internal func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
+    func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
         let moveCell = seoulCafeteriaList[sourceIndexPath.row]
         seoulCafeteriaList.remove(at: sourceIndexPath.row)
         seoulCafeteriaList.insert(moveCell, at: destinationIndexPath.row)
-        UserDefaults.standard.seoulCafeteria = seoulCafeteriaList
+        UserDefaults.standard.seoulCafeteria = seoulCafeteriaList.map({
+            guard let cafeteria = Cafeteria(rawValue: $0.rawValue) else { fatalError() }
+            return cafeteria.rawValue
+        })
+        print(UserDefaults.standard.seoulCafeteria)
         tableView.reloadData()
     }
 }

--- a/NyamNyam/NyamNyam/Screens/Setting/SettingViewController.swift
+++ b/NyamNyam/NyamNyam/Screens/Setting/SettingViewController.swift
@@ -10,6 +10,7 @@ import SnapKit
 
 final class SettingViewController: UIViewController {
     lazy var settingListModule = SettingListTableViewController()
+    lazy var setCafeteriaOrderModule = SetCafeteriaOrderTableViewController()
     
     func setNavigationBarBackButton() {
         let backBarButtonItem = UIBarButtonItem(title: "설정", style: .plain, target: self, action: nil)
@@ -21,6 +22,7 @@ final class SettingViewController: UIViewController {
         super.viewDidLoad()
         setNavigationBarBackButton()
         self.view.backgroundColor = Pallete.gray50.color
+        self.setCafeteriaOrderLayout()
         self.setSettingListLayout()
     }
 }
@@ -32,8 +34,20 @@ private extension SettingViewController {
         self.view.addSubview(settingListModule.view)
         settingListModule.didMove(toParent: self)
         settingListModule.view.snp.makeConstraints { make in
-            make.top.equalToSuperview().offset(490)
-            make.leading.trailing.bottom.equalToSuperview()
+            make.top.equalTo(setCafeteriaOrderModule.view.snp.bottom).offset(16)
+            make.leading.trailing.equalToSuperview()
+            make.height.equalTo(151)
+        }
+    }
+    
+    private func setCafeteriaOrderLayout() {
+        self.addChild(setCafeteriaOrderModule)
+        self.view.addSubview(setCafeteriaOrderModule.view)
+        setCafeteriaOrderModule.didMove(toParent: self)
+        setCafeteriaOrderModule.view.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(100)
+            make.leading.trailing.equalToSuperview()
+            make.height.equalTo(270)
         }
     }
 }


### PR DESCRIPTION
# SettingView의 카페테리아 순서를 변경하는 섹션을 구현합니다

#38

- Drag&Drop 이 가능한 TableView를 구현하였습니다.
- Drag&Drop을 통해 카페테리아의 순서를 변경하고 UserDefaults에 변경된 순서를 업로드하도록 구현하였습니다.
![Simulator Screen Recording - iPhone 13 - 2023-03-13 at 22 28 28](https://user-images.githubusercontent.com/103012087/224715776-ab28fc72-87ed-4fc8-93f9-560243a2593c.gif)

### 이전 PR #40 의 UITableView와 분리하여 2개의 UITableView를 사용한 이유는
DragDelegate과 DropDelegate가 채택되어야하기 때문입니다.
DrageDelegate과 DropDelegate를 채택하는 경우 움직임이 없어도 되는 2번째 섹션도 움직일 우려가 있기 때문에 따로 구현하였습니다.
> 지금 확인하니 같은 UITableView여도 섹션을 구분하면 따로 구현할 수 있을 것 같습니다.
추후에 좀 더 알아보고 리팩토링 할 수 있을 것 같은데 2개로 선언하는 게 나을까요 ?

## Drag & Drop 이 가능한 TableView를 구현합니다.

UITableView의 DragDelegate과 DropDelegate를 활용하여 구현하였습니다.
DragDelegate은 cell을 drag 할 수 있도록 하는 delegate 입니다.
DropDelegate은 cell을 drop 하도록 하는 delegate 입니다.

이 두가지 Delegate으로는 Drag & Drop은 구현이 되지만 Drop 후의 데이터 변경은 동작하지 않습니다.
따라서 UITableViewDataSource에서 제공하는 함수를 구현해야합니다.

## Drag & Drop을 통해 카페테리아의 순서를 변경하고 UserDefaults에 변경된 순서를 업로드 합니다.

```swift
func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
        let cell = seoulCafeteriaList[sourceIndexPath.row]
        seoulCafeteriaList.remove(at: sourceIndexPath.row)
        seoulCafeteriaList.insert(cell, at: destinationIndexPath.row)
        UserDefaults.standard.seoulCafeteria = seoulCafeteriaList.map({
            guard let cafeteria = Cafeteria(rawValue: $0.rawValue) else { fatalError() }
            return cafeteria.rawValue
        })
        tableView.reloadData()
    }
```

위의 함수는 cell이 움직일 시에 움직이기 전의 `sourceIndexPath`와 움직인 후의 `destinationIndexPath`를 가지고 있는 `UITableViewDataSource` 에서 제공하는 함수입니다.

### drag한 cell의  `IndexPath` 변경
따라서 움직일 cell의 `sourceIndexPath`(인덱스)를 cell의 데이터 배열(`seoulCafeteriaList`)에서 삭제하고 움직인 후의 값을 움직인 후의 인덱스에 넣어주는 방식으로 구현하였습니다.

또한 이 이후에 UserDefaults를 활용하여 변경사항을 저장하도록 구현하였습니다.

### 변경한 cell의 인덱스 번호 재구성
`tableView.reloadData()`는
cell의 순서가 바뀌어도 맨 앞의 인덱스 번호는 유지되어야 하기 때문에 사용했습니다.

cell의 `cafeteriaNumberImageView` 는 `indexPath.row`로 전달되어 고정값이기 때문에 데이터가 변경되어도 `reload`가 되면 인덱스의 번호가 순서대로 다시 돌아오게 됩니다.

## + 리뷰 요청 사항

seoul, ansung에 따라서 `[Cafeteria] `배열을 선언하고 `getCafeteriaName()` 에서 `String`으로 반환하여 Cell의 `title`로 사용하도록 하였습니다.

UserDefaults의 기본 데이터 값을 사용할 수 없어서 따로 구현후에 변경하도록 하였는데 더 좋은 방법이 있다면 리뷰 부탁드립니다 !

```swift
UserDefaults.standard.seoulCafeteria = seoulCafeteriaList.map({
       guard let cafeteria = Cafeteria(rawValue: $0.rawValue) else { fatalError() }
       return cafeteria.rawValue
})
```

이외에도 현재 UITableView 에서 Scroll을 비활성화 하는 것이 나아보이는데 어떻게 생각하시나요 ?? 리뷰 부탁드립니다!

## 참고
https://djgmd1021.tistory.com/143
https://vincentgeranium.github.io/swift,/ios/2019/04/16/TableView-IndexPath.html