### PR TITLE
SettingView의 UI를 수정합니다

### DIFF
--- a/NyamNyam/NyamNyam/Screens/Setting/Components/BackButtonView.swift
+++ b/NyamNyam/NyamNyam/Screens/Setting/Components/BackButtonView.swift
@@ -33,6 +33,7 @@ final class BackButtonView: UIView {
     private let buttonImage: UIImageView = {
         let image = UIImageView()
         image.image = UIImage(systemName: "chevron.left")
+        image.sizeToFit()
         image.tintColor = Pallete.gray.color
         return image
     }()
@@ -63,7 +64,7 @@ private extension BackButtonView {
         self.addSubview(buttonImage)
         buttonImage.snp.makeConstraints { make in
             make.leading.equalToSuperview().offset(7.29)
-            make.top.equalToSuperview().offset(safeAreaTopInset() ?? 63)
+            make.top.equalToSuperview().offset((safeAreaTopInset() ?? 50) + 13)
             make.bottom.equalToSuperview()
             make.height.equalTo(24)
         }
@@ -75,7 +76,7 @@ private extension BackButtonView {
         buttonLabel.snp.makeConstraints { make in
             make.leading.equalTo(buttonImage.snp.trailing).offset(14)
             make.centerY.equalTo(buttonImage.snp.centerY)
-            make.top.equalToSuperview().offset(safeAreaTopInset() ?? 63)
+            make.top.equalToSuperview().offset((safeAreaTopInset() ?? 50) + 13)
             make.bottom.equalToSuperview()
         }
         buttonLabel.isUserInteractionEnabled = false
@@ -87,7 +88,7 @@ private extension BackButtonView {
         backButton.snp.makeConstraints { make in
             make.leading.equalTo(buttonImage.snp.leading)
             make.trailing.equalTo(buttonLabel.snp.trailing)
-            make.top.equalToSuperview().offset(safeAreaTopInset() ?? 63)
+            make.top.equalToSuperview().offset((safeAreaTopInset() ?? 50) + 13)
             make.bottom.equalToSuperview()
         }
         backButton.backgroundColor = .clear

--- a/NyamNyam/NyamNyam/Screens/Setting/Components/BackButtonView.swift
+++ b/NyamNyam/NyamNyam/Screens/Setting/Components/BackButtonView.swift
@@ -11,15 +11,9 @@ import SnapKit
 final class BackButtonView: UIView {
     
     func safeAreaTopInset() -> CGFloat? {
-        if #available(iOS 13.0, *) {
-            let window = UIApplication.shared.windows.first
-            guard let topArea = window?.safeAreaInsets.top else { return nil }
-            return topArea
-        } else {
-            let window = UIApplication.shared.keyWindow
-            guard let topArea = window?.safeAreaInsets.top else { return nil }
-            return topArea
-        }
+        let window = UIApplication.shared.windows.first
+        guard let topArea = window?.safeAreaInsets.top else { return nil }
+        return topArea
     }
     
     private let buttonLabel: UILabel = {
@@ -59,7 +53,7 @@ final class BackButtonView: UIView {
 }
 
 private extension BackButtonView {
-
+    
     private func setBackButtonImageLayout() {
         self.addSubview(buttonImage)
         buttonImage.snp.makeConstraints { make in
@@ -82,7 +76,7 @@ private extension BackButtonView {
         buttonLabel.isUserInteractionEnabled = false
     }
     
-
+    
     private func setBackButtonLayout() {
         self.addSubview(backButton)
         backButton.snp.makeConstraints { make in

--- a/NyamNyam/NyamNyam/Screens/Setting/Components/BackButtonView.swift
+++ b/NyamNyam/NyamNyam/Screens/Setting/Components/BackButtonView.swift
@@ -10,6 +10,18 @@ import SnapKit
 
 final class BackButtonView: UIView {
     
+    func safeAreaTopInset() -> CGFloat? {
+        if #available(iOS 13.0, *) {
+            let window = UIApplication.shared.windows.first
+            guard let topArea = window?.safeAreaInsets.top else { return nil }
+            return topArea
+        } else {
+            let window = UIApplication.shared.keyWindow
+            guard let topArea = window?.safeAreaInsets.top else { return nil }
+            return topArea
+        }
+    }
+    
     private let buttonLabel: UILabel = {
         let label = UILabel()
         label.text = "설정"
@@ -51,7 +63,7 @@ private extension BackButtonView {
         self.addSubview(buttonImage)
         buttonImage.snp.makeConstraints { make in
             make.leading.equalToSuperview().offset(7.29)
-            make.top.equalToSuperview().offset(63)
+            make.top.equalToSuperview().offset(safeAreaTopInset() ?? 63)
             make.bottom.equalToSuperview()
             make.height.equalTo(24)
         }
@@ -63,7 +75,7 @@ private extension BackButtonView {
         buttonLabel.snp.makeConstraints { make in
             make.leading.equalTo(buttonImage.snp.trailing).offset(14)
             make.centerY.equalTo(buttonImage.snp.centerY)
-            make.top.equalToSuperview().offset(63)
+            make.top.equalToSuperview().offset(safeAreaTopInset() ?? 63)
             make.bottom.equalToSuperview()
         }
         buttonLabel.isUserInteractionEnabled = false
@@ -75,7 +87,7 @@ private extension BackButtonView {
         backButton.snp.makeConstraints { make in
             make.leading.equalTo(buttonImage.snp.leading)
             make.trailing.equalTo(buttonLabel.snp.trailing)
-            make.top.equalToSuperview().offset(63)
+            make.top.equalToSuperview().offset(safeAreaTopInset() ?? 63)
             make.bottom.equalToSuperview()
         }
         backButton.backgroundColor = .clear

--- a/NyamNyam/NyamNyam/Screens/Setting/Components/SetCafeteriaOrderModule/SetCafeteriaOrderTableViewController.swift
+++ b/NyamNyam/NyamNyam/Screens/Setting/Components/SetCafeteriaOrderModule/SetCafeteriaOrderTableViewController.swift
@@ -11,8 +11,6 @@ import SnapKit
 final class SetCafeteriaOrderTableViewController: UIViewController {
     
     private var cafeteriaList: [String]
-    private var seoulCafeteriaList: [String] = UserDefaults.standard.seoulCafeteria
-    private var ansungCafeteriaList: [String] = UserDefaults.standard.ansungCafeteria
     private var isSeoulCafeteria: Bool = true
     
     private func getCafeteriaName(_ cafeteria: String) -> String {
@@ -49,10 +47,10 @@ final class SetCafeteriaOrderTableViewController: UIViewController {
     
     init(viewModel: SettingViewModel) {
         if viewModel.currentCampus.value == .seoul {
-            cafeteriaList = seoulCafeteriaList
+            cafeteriaList = UserDefaults.standard.seoulCafeteria
             isSeoulCafeteria = true
         } else {
-            cafeteriaList = ansungCafeteriaList
+            cafeteriaList = UserDefaults.standard.ansungCafeteria
             isSeoulCafeteria = false
         }
         super.init(nibName: nil, bundle: nil)

--- a/NyamNyam/NyamNyam/Screens/Setting/Components/SettingListViewModule/Components/SettingWebViewController.swift
+++ b/NyamNyam/NyamNyam/Screens/Setting/Components/SettingListViewModule/Components/SettingWebViewController.swift
@@ -12,19 +12,37 @@ import WebKit
 final class SettingWebViewController: UIViewController {
     var webView: WKWebView!
     var webURL: String = ""
-
+    
+    lazy var backButton = BackButtonView()
+    
+    @objc func backButtonPressed(_ sender: UIButton) {
+        self.navigationController?.popViewController(animated: true)
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
+        view.backgroundColor = .white
+        setBackButtonLayout()
+        backButton.backButton.addTarget(self, action: #selector(backButtonPressed), for: .touchUpInside)
         setWebView()
         setWebViewLayout()
+        view.insetsLayoutMarginsFromSafeArea = true
     }
     
     override func viewDidAppear(_ animated: Bool) {
-           super.viewDidAppear(animated)
+        super.viewDidAppear(animated)
     }
 }
 
 private extension SettingWebViewController {
+    
+    func setBackButtonLayout() {
+        view.addSubview(backButton)
+        backButton.snp.makeConstraints { make in
+            make.top.leading.trailing.equalToSuperview()
+        }
+    }
+    
     func setWebView() {
         let webConfiguration = WKWebViewConfiguration()
         webView = WKWebView(frame: .zero, configuration: webConfiguration)
@@ -38,7 +56,8 @@ private extension SettingWebViewController {
     func setWebViewLayout() {
         view.addSubview(webView)
         webView.snp.makeConstraints { make in
-            make.top.leading.trailing.bottom.equalToSuperview()
+            make.top.equalTo(backButton.snp.bottom).offset(10)
+            make.leading.trailing.bottom.equalToSuperview()
         }
     }
 }

--- a/NyamNyam/NyamNyam/Screens/Setting/SettingViewController.swift
+++ b/NyamNyam/NyamNyam/Screens/Setting/SettingViewController.swift
@@ -44,7 +44,6 @@ final class SettingViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        setNavigationBarBackButton()
         setDefaultNavigationBar()
         self.setBackButtonLayout()
         backButton.backButton.addTarget(self, action: #selector(backButtonPressed), for: .touchUpInside)
@@ -60,13 +59,24 @@ final class SettingViewController: UIViewController {
         viewModel.currentCampus.observe(on: self) { [weak self] _ in
             self?.setCampusLabelText()
             self?.resetSetCafeteriaOrderModule()
+            self?.resetSettingListModule()
         }
     }
     
     private func resetSetCafeteriaOrderModule() {
+        setCafeteriaOrderModule.willMove(toParent: nil)
+        setCafeteriaOrderModule.view.removeFromSuperview()
         setCafeteriaOrderModule.removeFromParent()
         setCafeteriaOrderModule = SetCafeteriaOrderTableViewController(viewModel: viewModel)
         setCafeteriaOrderLayout()
+    }
+    
+    private func resetSettingListModule() {
+        settingListModule.willMove(toParent: nil)
+        settingListModule.view.removeFromSuperview()
+        settingListModule.removeFromParent()
+        settingListModule = SettingListTableViewController()
+        setSettingListLayout()
     }
     
     private func setDefaultNavigationBar() {
@@ -96,7 +106,7 @@ private extension SettingViewController {
         setDefaultCampusModule.snp.makeConstraints { make in
             make.top.equalTo(backButton.snp.bottom)
             make.leading.trailing.equalToSuperview()
-            make.height.equalTo(50)
+            make.height.equalTo(55)
         }
     }
     
@@ -107,7 +117,7 @@ private extension SettingViewController {
         setCafeteriaOrderModule.view.snp.makeConstraints { make in
             make.top.equalTo(setDefaultCampusModule.snp.bottom).offset(16)
             make.leading.trailing.equalToSuperview()
-            make.height.equalTo(270)
+            make.height.equalTo(viewModel.currentCampus.value == .seoul ?  UserDefaults.standard.seoulCafeteria.count * 40 + 58 : UserDefaults.standard.ansungCafeteria.count * 40 + 58)
         }
     }
     
@@ -118,7 +128,6 @@ private extension SettingViewController {
         settingListModule.view.snp.makeConstraints { make in
             make.top.equalTo(setCafeteriaOrderModule.view.snp.bottom).offset(16)
             make.leading.trailing.bottom.equalToSuperview()
-            
         }
     }
     

--- a/NyamNyam/NyamNyam/Screens/Setting/SettingViewController.swift
+++ b/NyamNyam/NyamNyam/Screens/Setting/SettingViewController.swift
@@ -44,8 +44,8 @@ final class SettingViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        setDefaultNavigationBar()
         setNavigationBarBackButton()
+        setDefaultNavigationBar()
         self.setBackButtonLayout()
         backButton.backButton.addTarget(self, action: #selector(backButtonPressed), for: .touchUpInside)
         self.view.backgroundColor = Pallete.bgGray.color
@@ -72,12 +72,6 @@ final class SettingViewController: UIViewController {
     private func setDefaultNavigationBar() {
         self.navigationController?.setNavigationBarHidden(true, animated: true)
         self.navigationController?.interactivePopGestureRecognizer?.delegate = nil
-    }
-    
-    private func setNavigationBarBackButton() {
-        let backBarButtonItem = UIBarButtonItem(title: "설정", style: .plain, target: self, action: nil)
-        backBarButtonItem.tintColor = .black
-        self.navigationItem.backBarButtonItem = backBarButtonItem
     }
     
     @objc func backButtonPressed(_ sender: UIButton) {


### PR DESCRIPTION
# SettingView의 UI를 수정합니다

Close #38

- 중앙대 포탈, 개인정보 정책 WebView의 뒤로가기 버튼을 커스텀 BackButton으로 변경하였습니다.
- 캠퍼스 변경에 따라 SetCafeteriaOrderModule 의 높이가 변경되도록 구현하였습니다.
- BackButton의 위치를 수정하였습니다.

### 1. WebView의 뒤로가기 버튼을 커스텀 BackButton으로 변경하였습니다.

기존 뒤로가기 버튼은 기본 navigationBar의 item을 사용하였는데 상위 ViewController에서 사용하는 BackButton으로 변경하였습니다.

BackButton의 autoLayout에 현재 아이폰 기종을 검사하여 SafeArea에 따라서 위치를 조정하면서
기존 개인정보 정책 노션 페이지가 SafeArea를 벗어나는 이슈를 해결하였습니다.

### 2. SetCafeteriaOrderModule을 캠퍼스에 따라 높이를 수정하였습니다.

안성캠퍼스의 경우 3개의 카페테리아, 서울캠퍼스의 경우 5개의 카페테리아 메뉴를 갖게되는데

이때 Hi-fi 디자인에 따라서 캠퍼스에 따라 높이를 조정하도록 구현하였습니다

```swift
setCafeteriaOrderModule.view.snp.makeConstraints { make in
            make.top.equalTo(setDefaultCampusModule.snp.bottom).offset(16)
            make.leading.trailing.equalToSuperview()
            make.height.equalTo(viewModel.currentCampus.value == .seoul ?  UserDefaults.standard.seoulCafeteria.count * 40 + 58 : UserDefaults.standard.ansungCafeteria.count * 40 + 58)
        }
```

viewModel의 currentCampus에 따라서 각 캠퍼스의 UserDefaults cafeteria 수 만큼 높이를 지정하였습니다.

```swift
private func resetSetCafeteriaOrderModule() {
        setCafeteriaOrderModule.willMove(toParent: nil)
        setCafeteriaOrderModule.view.removeFromSuperview()
        setCafeteriaOrderModule.removeFromParent()
        setCafeteriaOrderModule = SetCafeteriaOrderTableViewController(viewModel: viewModel)
        setCafeteriaOrderLayout()
    }
    
    private func resetSettingListModule() {
        settingListModule.willMove(toParent: nil)
        settingListModule.view.removeFromSuperview()
        settingListModule.removeFromParent()
        settingListModule = SettingListTableViewController()
        setSettingListLayout()
    }
```

기존 버벅이는 것처럼 보였던 문제는 ChildView가 완전히 Parent에서 제거되지 않아 발생했던 문제였습니다.
viewModel의 currentCampus 가 변경됨에 따라 ChildView를 완전히 제거하여 해결하였습니다.

### 3. BackButton의 위치를 수정하였습니다.

BackButton의 AutoLayout이 기존에는 SafeArea를 고려하여 상수로 들어가있었지만
아이폰 8, SE 기종의 경우 노치가 존재하지 않기 때문에 공백이 생기는 이슈가 있었습니다.

따라서 SafeArea의 크기를 반환하는 함수를 구현하고 반환된 크기만큼을 top의 offset 값으로 전달하여 해결하였습니다.

SafeArea 크기를 구하는 함수는 아래와 같습니다.

```swift
func safeAreaTopInset() -> CGFloat? {
        if #available(iOS 13.0, *) {
            let window = UIApplication.shared.windows.first
            guard let topArea = window?.safeAreaInsets.top else { return nil }
            return topArea
        } else {
            let window = UIApplication.shared.keyWindow
            guard let topArea = window?.safeAreaInsets.top else { return nil }
            return topArea
        }
    }
```