### PR TITLE
네트워크 미연결 시에 WebView의 Alert를 구현하였습니다

### DIFF
--- a/NyamNyam/NyamNyam/Screens/Setting/Components/SettingListViewModule/Components/SettingWebViewController.swift
+++ b/NyamNyam/NyamNyam/Screens/Setting/Components/SettingListViewModule/Components/SettingWebViewController.swift
@@ -20,7 +20,17 @@ final class SettingWebViewController: UIViewController {
     }
     
     override func viewDidAppear(_ animated: Bool) {
-           super.viewDidAppear(animated)
+        super.viewDidAppear(animated)
+        
+        guard Reachability.networkConnected() else {
+            let alert = UIAlertController(title: "네트워크가 원활하지 않습니다", message: "연결 상태를 확인해주세요", preferredStyle: .alert)
+            let okAction = UIAlertAction(title: "닫기", style: .default) {  _ in
+                self.navigationController?.popViewController(animated: true)
+            }
+            alert.addAction(okAction)
+            self.present(alert, animated: true, completion: nil)
+            return
+        }
     }
 }
 


### PR DESCRIPTION
# Reachability를 사용하여 네트워크가 연결되어있지 않을 시 WebView의 Alert를 구현하였습니다.
Close #57 

- 네트워크가 연결되어있지 않을 시에 즉시 Alert 창을 띄우기 위해 ViewDidAppear에 작성하였으며
Alert 창의 닫기를 누를시 ViewController 를 pop하여 뒤로 가도록 구현하였습니다.

```swift 
    override func viewDidAppear(_ animated: Bool) {
        super.viewDidAppear(animated)
        
        guard Reachability.networkConnected() else {
            let alert = UIAlertController(title: "네트워크가 원활하지 않습니다", message: "연결 상태를 확인해주세요", preferredStyle: .alert)
            let okAction = UIAlertAction(title: "닫기", style: .default) {  _ in
                self.navigationController?.popViewController(animated: true)
            }
            alert.addAction(okAction)
            self.present(alert, animated: true, completion: nil)
            return
        }
    }
}
```

테스트 결과 정상적으로 작동하는 것을 확인하였습니다.

https://user-images.githubusercontent.com/103012087/225562325-4818125b-605e-4186-895a-f241a4f0eff6.mp4


