### PR TITLE
네트워크의 연결 여부와 데이터가 최신화된 상태라면 저장하지 않도록 구현합니다.

### DIFF
--- a/NyamNyam/NyamNyam/Application/SceneDelegate.swift
+++ b/NyamNyam/NyamNyam/Application/SceneDelegate.swift
@@ -8,37 +8,37 @@
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-
+    
     var window: UIWindow?
-
-
+    
+    
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
-            let viewController = HomeViewController()
-            let navigationController = UINavigationController(rootViewController: viewController)
-            
-            self.window = UIWindow(windowScene: windowScene)
-            self.window?.rootViewController = navigationController
-            self.window?.makeKeyAndVisible()
+        let viewController = HomeViewController()
+        let navigationController = UINavigationController(rootViewController: viewController)
+        
+        self.window = UIWindow(windowScene: windowScene)
+        self.window?.rootViewController = navigationController
+        self.window?.makeKeyAndVisible()
     }
-
+    
     func sceneDidDisconnect(_ scene: UIScene) {
         // Called as the scene is being released by the system.
         // This occurs shortly after the scene enters the background, or when its session is discarded.
         // Release any resources associated with this scene that can be re-created the next time the scene connects.
         // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
     }
-
+    
     func sceneDidBecomeActive(_ scene: UIScene) {
         // Called when the scene has moved from an inactive state to an active state.
         // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
     }
-
+    
     func sceneWillResignActive(_ scene: UIScene) {
         // Called when the scene will move from an active state to an inactive state.
         // This may occur due to temporary interruptions (ex. an incoming phone call).
     }
-
+    
     func sceneWillEnterForeground(_ scene: UIScene) {
         // Called as the scene transitions from the background to the foreground.
         // Use this method to undo the changes made on entering the background.
@@ -52,13 +52,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             print("네트워크 연결안됨")
         }
     }
-
+    
     func sceneDidEnterBackground(_ scene: UIScene) {
         // Called as the scene transitions from the foreground to the background.
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.
     }
-
-
+    
+    
 }
 

--- a/NyamNyam/NyamNyam/Application/SceneDelegate.swift
+++ b/NyamNyam/NyamNyam/Application/SceneDelegate.swift
@@ -14,12 +14,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
-        let viewController = HomeViewController()
-        let navigationController = UINavigationController(rootViewController: viewController)
-        
-        window = UIWindow(windowScene: windowScene)
-        window?.rootViewController = navigationController
-        window?.makeKeyAndVisible()
+            let viewController = HomeViewController()
+            let navigationController = UINavigationController(rootViewController: viewController)
+            
+            self.window = UIWindow(windowScene: windowScene)
+            self.window?.rootViewController = navigationController
+            self.window?.makeKeyAndVisible()
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {
@@ -43,12 +43,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Called as the scene transitions from the background to the foreground.
         // Use this method to undo the changes made on entering the background.
         
-        //MARK: 임시 테스트 구문 추후 FireStore 업로드 로직 변경예정
+        //MARK: 네트워크 검사 후 FireStore 내려받기
         if Reachability.networkConnected() {
+            FBManager.shared.getMealJson()
             UserDefaults.standard.lastUploadDate = Date().toFullTimeString()
-            print(UserDefaults.standard.lastUploadDate)
         } else {
-            print("네트워크 연결 오류")
+            //TODO: 테스트구문 추후 UI 이벤트 처리 예정
+            print("네트워크 연결안됨")
         }
     }
 

--- a/NyamNyam/NyamNyam/Global/Manager/JsonManager.swift
+++ b/NyamNyam/NyamNyam/Global/Manager/JsonManager.swift
@@ -13,12 +13,12 @@ final class JsonManager {
     
     func jsonToString() -> String? {
         guard let filename = getDocumentsDirectory()?.appendingPathComponent("CAUMeals.json") else { return nil }
-            do {
-                let stringData = try String(contentsOf: filename, encoding: String.Encoding.utf8)
-                return stringData
-            } catch {
-                return nil
-            }
+        do {
+            let stringData = try String(contentsOf: filename, encoding: String.Encoding.utf8)
+            return stringData
+        } catch {
+            return nil
+        }
     }
     func saveJson(_ strData: String) {
         guard let filename = getDocumentsDirectory()?.appendingPathComponent("CAUMeals.json") else { return }

--- a/NyamNyam/NyamNyam/Global/Manager/JsonManager.swift
+++ b/NyamNyam/NyamNyam/Global/Manager/JsonManager.swift
@@ -17,7 +17,7 @@ final class JsonManager {
                 let stringData = try String(contentsOf: filename, encoding: String.Encoding.utf8)
                 return stringData
             } catch {
-                fatalError("Failed to load \(filename) from bundle.")
+                return nil
             }
     }
     func saveJson(_ strData: String) {

--- a/NyamNyam/NyamNyam/Network/Firebase/FBManager.swift
+++ b/NyamNyam/NyamNyam/Network/Firebase/FBManager.swift
@@ -17,14 +17,16 @@ final class FBManager {
     func getMealJson() {
         let db = FirebaseFirestore.Firestore.firestore()
         let docRef = db.collection("CAU_Haksik").document("CAU_Cafeteria_Menu")
-        
-        docRef.getDocument(source: .cache) { (document, error) in
-            if let document = document {
+        docRef.getDocument() { (document, error) in
+            if let document = document, document.exists {
                 guard let dataDescription = document.data() else { return }
                 do {
                     let jsonData = try JSONSerialization.data(withJSONObject: dataDescription, options: .sortedKeys)
                     guard let strData = String(data: jsonData, encoding: .utf8) else { return }
-                    JsonManager.shared.saveJson(strData)
+                    guard strData == JsonManager.shared.jsonToString() else {
+                        JsonManager.shared.saveJson(strData)
+                        return
+                    }
                 } catch {
                     print(error.localizedDescription)
                 }
@@ -33,5 +35,4 @@ final class FBManager {
             }
         }
     }
-    
 }


### PR DESCRIPTION
# 네트워크의 연결 여부와 데이터가 최신화된 상태라면 저장하지 않도록 구현합니다.

#52

- FireStore의 데이터와 현재 로컬 데이터를 비교하여 로컬에 덮어쓰지 않도록 구현하였습니다.

```swift
func getMealJson() {
        let db = FirebaseFirestore.Firestore.firestore()
        let docRef = db.collection("CAU_Haksik").document("CAU_Cafeteria_Menu")
        docRef.getDocument() { (document, error) in
            if let document = document, document.exists {
                guard let dataDescription = document.data() else { return }
                do {
                    let jsonData = try JSONSerialization.data(withJSONObject: dataDescription, options: .sortedKeys)
                    guard let strData = String(data: jsonData, encoding: .utf8) else { return }
                    guard strData == JsonManager.shared.jsonToString() else {
                        JsonManager.shared.saveJson(strData)
                        return
                    }
                } catch {
                    print(error.localizedDescription)
                }
            } else {
                return
            }
        }
    }
```

비교를 위해 FireStore에서 데이터를 내려받은 뒤에 String으로 파싱합니다.
기존 로컬에 있는 데이터 역시 `JsonToString()` 으로 String으로 파싱한 후에 비교합니다.

> 이를 위해 기존 `jsonToString()`에서 초기 저장파일이 없을 시 `fatalerror`를 발생시키는 것이 아닌 `nil`을 return 하도록 하였습니다.
> 

> 따라서 앱을 처음 설치하였을 시에는 무조건적으로 내려받고 저장하도록 구현하였습니다.
> 

비교 후 최신화가 필요하다면 `JsonManager`의 `saveJson()`을 호출하여 최신화합니다.

```swift
func sceneWillEnterForeground(_ scene: UIScene) {
        
        //MARK: 네트워크 검사 후 FireStore 내려받기
        if Reachability.networkConnected() {
            FBManager.shared.getMealJson()
            UserDefaults.standard.lastUploadDate = Date().toFullTimeString()
        } else {
            //TODO: 테스트구문 추후 UI 이벤트 처리 예정
            print("네트워크 연결안됨")
        }
    }
```

getMealJson이 들어갈 부분은 Scene이 Background에서 Foreground로 들어가는 과정에서 들어가게 됩니다.
앱을 처음 설치할 시에 필요한지 확인해본 결과 `sceneWillEnterForeground()` 가 `FirstLaunch` 이후에 실행되는 것을 확인하였으므로 `SceneDelegate`에만 들어가면 될 것 같다고 판단하였습니다.

이때 네트워크를 검사한 후에 네트워크가 연결되어 있다면 `getMealJson()`을 호출하여 검사하는 방식을 활용하였습니다.

네트워크가 연결되어 있지 않다면 `HomeViewController`로 그대로 이동한 후에 다른 이벤트 처리를 해주어야할 것 같은데 Background에서 Foreground로 가는 경우가 많은 만큼 `Alert`를 띄우는 게 나을지
`UserNotification`을 따로 Foreground 상황에서만 사용할지 등 어떤 방식을 사용할지 논의를 해보아야할 것 같습니다 ..!

지금 제 생각은 매번 `Alert`를 넣기에는 Foreground로 이동했을 시에 계속해서 확인해야하는 사용자의 불편함이 있을 것 같아서요 !