### PR TITLE
데이터 최신화 검사로직을 수정합니다

### DIFF
--- a/NyamNyam/NyamNyam/Application/SceneDelegate.swift
+++ b/NyamNyam/NyamNyam/Application/SceneDelegate.swift
@@ -49,8 +49,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         //MARK: 네트워크 검사 후 FireStore 내려받기
         if Reachability.networkConnected() {
-            FBManager.shared.getMealJson()
-            UserDefaults.standard.lastUploadDate = Date().toFullTimeString()
+            FBManager.shared.getMealJson() {
+                UserDefaults.standard.lastUploadDate = Date().toFullTimeString()
+            }
         } else {
             //TODO: 테스트구문 추후 UI 이벤트 처리 예정
             print("네트워크 연결안됨")

--- a/NyamNyam/NyamNyam/Network/Firebase/FBManager.swift
+++ b/NyamNyam/NyamNyam/Network/Firebase/FBManager.swift
@@ -23,10 +23,10 @@ final class FBManager {
                 do {
                     let jsonData = try JSONSerialization.data(withJSONObject: dataDescription, options: .sortedKeys)
                     guard let strData = String(data: jsonData, encoding: .utf8) else { return }
-                    guard strData == JsonManager.shared.jsonToString() else {
+                    if strData != JsonManager.shared.jsonToString() {
                         JsonManager.shared.saveJson(strData)
                         completion()
-                    }
+                    } else { completion() }
                 } catch {
                     print(error.localizedDescription)
                 }


### PR DESCRIPTION
# 데이터 최신화 검사로직과 Forground로 진입 시에 사용하게 되는 과정을 수정하였습니다.
#52 

#60 에 따라 CompletionHandler로 처리된 기존 로직을 `sceneWillEnterForeground()` 에서 사용하는 방식을 수정하였습니다. 

###  json 파일을 내려받은 뒤에 `lastUploadDate`를 최신화 해주도록 하였습니다.

```swift 
    func sceneWillEnterForeground(_ scene: UIScene) {
        // Called as the scene transitions from the background to the foreground.
        // Use this method to undo the changes made on entering the background.
        
        //MARK: 네트워크 검사 후 FireStore 내려받기
        if Reachability.networkConnected() {
            FBManager.shared.getMealJson() {
                UserDefaults.standard.lastUploadDate = Date().toFullTimeString()
            }
        } else {
            //TODO: 테스트구문 추후 UI 이벤트 처리 예정
            print("네트워크 연결안됨")
        }
    }
```

### `getMealJson()` 에서 데이터 최신화를 검사하는 로직을 수정하였습니다.

```swift
                    if strData != JsonManager.shared.jsonToString() {
                        JsonManager.shared.saveJson(strData)
                        completion()
                    } else { completion() }
```

`guard`문이 아닌 `if else` 문으로 수정하여 검사 후 `completion()`을 호출하도록 하였습니다.