### PR TITLE
HomeViewController의 상단 높이를 조정하였습니다

### DIFF
--- a/NyamNyam/NyamNyam/Screens/Home/HomeViewController.swift
+++ b/NyamNyam/NyamNyam/Screens/Home/HomeViewController.swift
@@ -44,6 +44,12 @@ final class HomeViewController: UIViewController {
     @objc func settingButtonPressed(_ sender: UIButton) {
         self.navigationController?.pushViewController(SettingViewController(), animated: true)
     }
+    
+    func safeAreaTopInset() -> CGFloat {
+        let window = UIApplication.shared.windows.first
+        guard let topArea = window?.safeAreaInsets.top else { return 50 }
+        return topArea
+    }
 }
 
 extension HomeViewController {
@@ -73,7 +79,7 @@ extension HomeViewController {
         self.view.addSubview(optionSelectModule.view)
         optionSelectModule.didMove(toParent: self)
         optionSelectModule.view.snp.makeConstraints { make in
-            make.top.equalTo(view.snp.top).offset(63)
+            make.top.equalTo(view.snp.top).offset(safeAreaTopInset() + 13)
             make.leading.equalToSuperview()
             make.trailing.equalToSuperview()
             make.height.equalTo(160)
@@ -83,7 +89,7 @@ extension HomeViewController {
     private func setSettingButtonLayout() {
         view.addSubview(settingButton)
         settingButton.snp.makeConstraints { make in
-            make.top.equalTo(view.snp.top).offset(63)
+            make.top.equalTo(view.snp.top).offset(safeAreaTopInset() + 13)
             make.trailing.equalToSuperview().offset(-19)
         }
         


### PR DESCRIPTION
# HomeViewController의 상단 높이를 조정하였습니다.
Close #65 
- SE 기종의 경우 SafeArea가 없을 시에 StatusBar와의 간격이 벌어지는 이슈가 있었고 따라서 `HomeViewController`의 `top offset` 값을 현재 기종의 StatusBar 까지의 크기를 리턴하는 `safeAreaTopInset()` 을 구하여 전달하였습니다
- guard 문을 활용하여 값이 없는 경우 SafeArea가 있다고 가정하여 50을 전달하도록 하였습니다.
>SafeArea가 있다고 가정한 이유는 SafeArea가 없는 기종의 경우 StatusBar와 간격이 벌어지는 이슈이지만  SafeArea가 없다고 가정할 시에는 SafeArea가 있는 기종의 경우 UI가 잘리기 때문입니다.

<img width = 400 src = "https://user-images.githubusercontent.com/103012087/226096565-4a418a29-f74c-4762-883d-c417d4dd2ed5.png">

테스트 결과 정상적으로 나오는 것을 확인하였습니다.