### PR TITLE
다운로드 동안 런치스크린이 뜨도록 했고, 설정창이 다크모드로 유지되도록 했습니다.

### DIFF
--- a/NyamNyam/NyamNyam/Application/Base.lproj/LaunchScreen.storyboard
+++ b/NyamNyam/NyamNyam/Application/Base.lproj/LaunchScreen.storyboard
@@ -12,7 +12,7 @@
         <!--LaunchScreenViewController-->
         <scene sceneID="EHf-IW-A2E">
             <objects>
-                <viewController id="01J-lp-oVM" userLabel="LaunchScreenViewController" sceneMemberID="viewController">
+                <viewController restorationIdentifier="LaunchScreenViewController" storyboardIdentifier="LaunchScreenViewController" title="LaunchScreenViewController" id="01J-lp-oVM" userLabel="LaunchScreenViewController" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/NyamNyam/NyamNyam/Application/SceneDelegate.swift
+++ b/NyamNyam/NyamNyam/Application/SceneDelegate.swift
@@ -16,8 +16,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
         self.window = UIWindow(windowScene: windowScene)
-        
-        let defaultWindow = UIViewController()
+        let storyboard = UIStoryboard(name: "LaunchScreen", bundle: nil)
+        let defaultWindow = storyboard.instantiateViewController(withIdentifier: "LaunchScreenViewController")
         self.window?.makeKeyAndVisible()
         self.window?.rootViewController = defaultWindow
         AlertManager.addAlert(defaultWindow,

--- a/NyamNyam/NyamNyam/Screens/Setting/Components/SettingListViewModule/Components/SettingListTableViewCell.swift
+++ b/NyamNyam/NyamNyam/Screens/Setting/Components/SettingListViewModule/Components/SettingListTableViewCell.swift
@@ -13,6 +13,7 @@ final class SettingListTableViewCell: UITableViewCell {
     private let settingTitleLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 16, weight: .semibold)
+        label.textColor = .black
         return label
     }()
     

--- a/NyamNyam/NyamNyam/Screens/Setting/SettingViewController.swift
+++ b/NyamNyam/NyamNyam/Screens/Setting/SettingViewController.swift
@@ -17,6 +17,14 @@ final class SettingViewController: UIViewController {
     lazy var setDefaultCampusModule = SetDefaultCampusView()
     lazy var backButton = BackButtonView()
     
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        if #available(iOS 13, *) {
+            return .darkContent
+        } else {
+            return .default
+        }
+    }
+    
     lazy var optionAlert: UIAlertController = {
         let alert = UIAlertController(title: "캠퍼스를 선택해주세요.",
                                       message: nil,


### PR DESCRIPTION
close #72 
close #73 

<br><br>

## 1. 다운로드 동안 런치페이지

기존의 UIViewController() 로 생성되었던 defaultWindow를 LaunchScreen으로 변경하였습니다.
런치스크린은 스토리보드에서 가져왔습니다.

```swift
        let storyboard = UIStoryboard(name: "LaunchScreen", bundle: nil)
        let defaultWindow = storyboard.instantiateViewController(withIdentifier: "LaunchScreenViewController")
```

<br><br>

## 2. 다크모드로 수정

텍스트 폰트를 black으로 고정하고, status bar을 다크모드로 고정하였습니다.

```swift
    private let settingTitleLabel: UILabel = {
        let label = UILabel()
        label.font = .systemFont(ofSize: 16, weight: .semibold)
        label.textColor = .black  // 수정된 부분
        return label
    }()
```

```swift
    override var preferredStatusBarStyle: UIStatusBarStyle {
        if #available(iOS 13, *) {
            return .darkContent
        } else {
            return .default
        }
    }
```
