### PR TITLE
Setting의 변경사항이 돌아갈 때 Home에 적용되도록 하였습니다.

### DIFF
--- a/NyamNyam/NyamNyam/Screens/Home/Components/OptionSelectModule/OptionSelectModuleViewController.swift
+++ b/NyamNyam/NyamNyam/Screens/Home/Components/OptionSelectModule/OptionSelectModuleViewController.swift
@@ -15,6 +15,9 @@ final class OptionSelectModuleViewController: UIViewController {
     lazy var cafeteriaSelectView = CafeteriaSelectView(viewModel: viewModel)
     
     public func resetModule() {
+        viewModel.indexOfDate.value = 0
+        viewModel.indexOfCafeteria.value = 0
+        
         campusSelectView.removeFromSuperview()
         dateSelectView.removeFromSuperview()
         cafeteriaSelectView.removeFromSuperview()
@@ -32,6 +35,13 @@ final class OptionSelectModuleViewController: UIViewController {
         cafeteriaSelectView.cafeteriaDelegate = self
         
         setCampusLabelText()
+        
+        let index = viewModel.indexOfCafeteria.value
+        cafeteriaSelectView.setScrollOffsetBy(buttonIndex: index)
+        cafeteriaSelectView.buttons.forEach {
+            if $0.buttonIndex == index { $0.isSelected() }
+            else { $0.isNotSelected() }
+        }
     }
     
     lazy var optionAlert: UIAlertController = {

--- a/NyamNyam/NyamNyam/Screens/Home/Components/OptionSelectModule/OptionSelectModuleViewController.swift
+++ b/NyamNyam/NyamNyam/Screens/Home/Components/OptionSelectModule/OptionSelectModuleViewController.swift
@@ -18,6 +18,8 @@ final class OptionSelectModuleViewController: UIViewController {
         viewModel.indexOfDate.value = 0
         viewModel.indexOfCafeteria.value = 0
         
+        viewModel.currentCampus.remove(observer: self)
+        
         campusSelectView.removeFromSuperview()
         dateSelectView.removeFromSuperview()
         cafeteriaSelectView.removeFromSuperview()
@@ -35,6 +37,12 @@ final class OptionSelectModuleViewController: UIViewController {
         cafeteriaSelectView.cafeteriaDelegate = self
         
         setCampusLabelText()
+        
+        viewModel.currentCampus.observe(on: self) { [weak self] _ in
+            self?.setCampusLabelText()
+            self?.resetCafeteriaView()
+            self?.initOptionIndex()
+        }
         
         let index = viewModel.indexOfCafeteria.value
         cafeteriaSelectView.setScrollOffsetBy(buttonIndex: index)

--- a/NyamNyam/NyamNyam/Screens/Home/Components/OptionSelectModule/OptionSelectModuleViewController.swift
+++ b/NyamNyam/NyamNyam/Screens/Home/Components/OptionSelectModule/OptionSelectModuleViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 final class OptionSelectModuleViewController: UIViewController {
-    let viewModel: HomeViewModel
+    var viewModel: HomeViewModel
     
     let campusSelectView = CampusSelectView()
     lazy var dateSelectView = DateSelectView(dateList: viewModel.dateList)

--- a/NyamNyam/NyamNyam/Screens/Home/Components/OptionSelectModule/OptionSelectModuleViewController.swift
+++ b/NyamNyam/NyamNyam/Screens/Home/Components/OptionSelectModule/OptionSelectModuleViewController.swift
@@ -8,11 +8,31 @@
 import UIKit
 
 final class OptionSelectModuleViewController: UIViewController {
-    var viewModel: HomeViewModel
+    let viewModel: HomeViewModel
     
-    let campusSelectView = CampusSelectView()
+    var campusSelectView = CampusSelectView()
     lazy var dateSelectView = DateSelectView(dateList: viewModel.dateList)
     lazy var cafeteriaSelectView = CafeteriaSelectView(viewModel: viewModel)
+    
+    public func resetModule() {
+        campusSelectView.removeFromSuperview()
+        dateSelectView.removeFromSuperview()
+        cafeteriaSelectView.removeFromSuperview()
+        
+        campusSelectView = CampusSelectView()
+        dateSelectView = DateSelectView(dateList: viewModel.dateList)
+        cafeteriaSelectView = CafeteriaSelectView(viewModel: viewModel)
+        
+        setCampusSelectViewLayout()
+        setDateSelectViewLayout()
+        setCafeteriaSelectViewLayout()
+        
+        campusSelectView.delegate = self
+        dateSelectView.delegate = self
+        cafeteriaSelectView.cafeteriaDelegate = self
+        
+        setCampusLabelText()
+    }
     
     lazy var optionAlert: UIAlertController = {
         let alert = UIAlertController(title: "캠퍼스를 선택해주세요.",

--- a/NyamNyam/NyamNyam/Screens/Home/ContentCarouselModule/ContentCarouselModuleViewController.swift
+++ b/NyamNyam/NyamNyam/Screens/Home/ContentCarouselModule/ContentCarouselModuleViewController.swift
@@ -10,7 +10,7 @@ import SnapKit
 
 final class ContentCarouselModuleViewController: UIViewController {
     
-    let viewModel: HomeViewModel
+    var viewModel: HomeViewModel
     
     private lazy var collectionViewFlowLayout: UICollectionViewFlowLayout = {
         let layout = UICollectionViewFlowLayout()

--- a/NyamNyam/NyamNyam/Screens/Home/ContentCarouselModule/ContentCarouselModuleViewController.swift
+++ b/NyamNyam/NyamNyam/Screens/Home/ContentCarouselModule/ContentCarouselModuleViewController.swift
@@ -10,7 +10,7 @@ import SnapKit
 
 final class ContentCarouselModuleViewController: UIViewController {
     
-    var viewModel: HomeViewModel
+    let viewModel: HomeViewModel
     
     private lazy var collectionViewFlowLayout: UICollectionViewFlowLayout = {
         let layout = UICollectionViewFlowLayout()

--- a/NyamNyam/NyamNyam/Screens/Home/HomeViewController.swift
+++ b/NyamNyam/NyamNyam/Screens/Home/HomeViewController.swift
@@ -40,6 +40,7 @@ final class HomeViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        optionSelectModule.resetModule()
     }
     
     private func setNetworkAlert() {

--- a/NyamNyam/NyamNyam/Screens/Home/HomeViewModel.swift
+++ b/NyamNyam/NyamNyam/Screens/Home/HomeViewModel.swift
@@ -5,7 +5,7 @@
 //  Created by Noah Park on 2023/02/27.
 //
 
-import Foundation
+import UIKit
 
 final class HomeViewModel {
     var currentCampus: Observable<Campus>
@@ -40,6 +40,25 @@ final class HomeViewModel {
         
         self.indexOfCafeteria = Observable(0)
         
+        NotificationCenter.default.addObserver(self, selector: #selector(handleSeoulCafeteriaChanged), name: UserDefaults.didChangeNotification, object: UserDefaults.standard)
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(handleAnsungCafeteriaChanged), name: UserDefaults.didChangeNotification, object: UserDefaults.standard)
+        
+    }
+    
+    
+    @objc func handleSeoulCafeteriaChanged() {
+        self.seoulCafeteriaList = UserDefaults.standard.seoulCafeteria.map {
+            guard let cafeteria = Cafeteria(rawValue: $0) else { fatalError() }
+            return cafeteria
+        }
+    }
+    
+    @objc func handleAnsungCafeteriaChanged() {
+        self.ansungCafeteriaList = UserDefaults.standard.ansungCafeteria.map {
+            guard let cafeteria = Cafeteria(rawValue: $0) else { fatalError() }
+            return cafeteria
+        }
     }
     
 }

--- a/NyamNyam/NyamNyam/Screens/Home/HomeViewModel.swift
+++ b/NyamNyam/NyamNyam/Screens/Home/HomeViewModel.swift
@@ -40,12 +40,18 @@ final class HomeViewModel {
         
         self.indexOfCafeteria = Observable(0)
         
+        NotificationCenter.default.addObserver(self, selector: #selector(handleCampusChanged), name: UserDefaults.didChangeNotification, object: UserDefaults.standard)
+        
         NotificationCenter.default.addObserver(self, selector: #selector(handleSeoulCafeteriaChanged), name: UserDefaults.didChangeNotification, object: UserDefaults.standard)
         
         NotificationCenter.default.addObserver(self, selector: #selector(handleAnsungCafeteriaChanged), name: UserDefaults.didChangeNotification, object: UserDefaults.standard)
         
     }
     
+    
+    @objc func handleCampusChanged() {
+        self.currentCampus = Observable(Campus(rawValue: UserDefaults.standard.campus) ?? .seoul)
+    }
     
     @objc func handleSeoulCafeteriaChanged() {
         self.seoulCafeteriaList = UserDefaults.standard.seoulCafeteria.map {


### PR DESCRIPTION
close #78 

<br><br>

### 1. UserDefaults 값의 변경사항을 추적합니다

다음과 같이 변경 사항을 추적해서, viewModel에서 사용하는 선택된 campus, cafeteria list들을 최신화 시켜주었습니다.

```swift
        NotificationCenter.default.addObserver(self, selector: #selector(handleCampusChanged), name: UserDefaults.didChangeNotification, object: UserDefaults.standard)
        
        NotificationCenter.default.addObserver(self, selector: #selector(handleSeoulCafeteriaChanged), name: UserDefaults.didChangeNotification, object: UserDefaults.standard)
        
        NotificationCenter.default.addObserver(self, selector: #selector(handleAnsungCafeteriaChanged), name: UserDefaults.didChangeNotification, object: UserDefaults.standard)
        
    }
    
    @objc func handleCampusChanged() {
        self.currentCampus = Observable(Campus(rawValue: UserDefaults.standard.campus) ?? .seoul)
    }
    
    @objc func handleSeoulCafeteriaChanged() {
        self.seoulCafeteriaList = UserDefaults.standard.seoulCafeteria.map {
            guard let cafeteria = Cafeteria(rawValue: $0) else { fatalError() }
            return cafeteria
        }
    }
    
    @objc func handleAnsungCafeteriaChanged() {
        self.ansungCafeteriaList = UserDefaults.standard.ansungCafeteria.map {
            guard let cafeteria = Cafeteria(rawValue: $0) else { fatalError() }
            return cafeteria
        }
    }
```

<br><br>

### 2. 해당 모듈을 다시 그려줍니다.

옵션을 고르는 모듈을 다시 그려줍니다.

변경된 부분을 조정하기 위해, 기존의 컴포넌트들을 remove 한 후, 다시 그려줍니다.
다음은 다시 그리기 위해 필요한 작업들을 넣어 놓은 `resetModule()` 코드입니다.

```swift
    public func resetModule() {
        viewModel.indexOfDate.value = 0
        viewModel.indexOfCafeteria.value = 0
        
        viewModel.currentCampus.remove(observer: self)
        
        campusSelectView.removeFromSuperview()
        dateSelectView.removeFromSuperview()
        cafeteriaSelectView.removeFromSuperview()
        
        campusSelectView = CampusSelectView()
        dateSelectView = DateSelectView(dateList: viewModel.dateList)
        cafeteriaSelectView = CafeteriaSelectView(viewModel: viewModel)
        
        setCampusSelectViewLayout()
        setDateSelectViewLayout()
        setCafeteriaSelectViewLayout()
        
        campusSelectView.delegate = self
        dateSelectView.delegate = self
        cafeteriaSelectView.cafeteriaDelegate = self
        
        setCampusLabelText()
        
        viewModel.currentCampus.observe(on: self) { [weak self] _ in
            self?.setCampusLabelText()
            self?.resetCafeteriaView()
            self?.initOptionIndex()
        }
        
        let index = viewModel.indexOfCafeteria.value
        cafeteriaSelectView.setScrollOffsetBy(buttonIndex: index)
        cafeteriaSelectView.buttons.forEach {
            if $0.buttonIndex == index { $0.isSelected() }
            else { $0.isNotSelected() }
        }
    }
```

<br><br>


## 3. 리팩토링이 필요한 부분

현재 `resetModule`이 viewWillAppear에 들어가 있어, 실제로 값이 바뀌지 않더라도 홈으로 돌아오면 무조건 다시 그리게 됩니다.

이 부분은 오버헤드가 크진 않지만 추후 수정이 필요합니다.

또한 마찬가지로 단순하게 viewWillAppear에 들어가 있기 떄문에 앱이 시작했을 때, 무조건 다시 그리게 되는데 (viewDidLoad에도 있으므로)

viewWillAppear가 viewDidLoad 이후이지만 사실 view가 그려지기 전에 실행되기 때문에 오버헤드는 없지만, 그래도 설정이 바뀌었을 때만 새로 그려지도록 수정이 필요해 보입니다.

해당 리팩토링 요구사항은 #81 issue에 올려놓았습니다.

<br><br>