### PR TITLE
WebView에 ProgressView를 추가하였습니다

### DIFF
--- a/NyamNyam/NyamNyam/Screens/Setting/Components/SettingListViewModule/Components/SettingWebViewController.swift
+++ b/NyamNyam/NyamNyam/Screens/Setting/Components/SettingListViewModule/Components/SettingWebViewController.swift
@@ -15,6 +15,14 @@ final class SettingWebViewController: UIViewController {
     
     lazy var backButton = BackButtonView()
     
+    lazy var progressView: UIProgressView = {
+        let progress = UIProgressView(progressViewStyle: .bar)
+        progress.progressTintColor = Pallete.cauBlue.color
+        progress.backgroundColor = Pallete.gray50.color
+        progress.progress = 0.0
+        return progress
+    }()
+    
     @objc func backButtonPressed(_ sender: UIButton) {
         self.navigationController?.popViewController(animated: true)
     }
@@ -24,6 +32,7 @@ final class SettingWebViewController: UIViewController {
         view.backgroundColor = .white
         setBackButtonLayout()
         backButton.backButton.addTarget(self, action: #selector(backButtonPressed), for: .touchUpInside)
+        setProgressViewLayout()
         setWebView()
         setWebViewLayout()
         view.insetsLayoutMarginsFromSafeArea = true
@@ -53,6 +62,15 @@ private extension SettingWebViewController {
         }
     }
     
+    func setProgressViewLayout() {
+        view.addSubview(progressView)
+        progressView.snp.makeConstraints { make in
+            make.top.equalTo(backButton.snp.bottom).offset(10)
+            make.leading.trailing.equalToSuperview()
+            make.height.equalTo(2.5)
+        }
+    }
+    
     func setWebView() {
         let webConfiguration = WKWebViewConfiguration()
         webView = WKWebView(frame: .zero, configuration: webConfiguration)
@@ -66,7 +84,7 @@ private extension SettingWebViewController {
     func setWebViewLayout() {
         view.addSubview(webView)
         webView.snp.makeConstraints { make in
-            make.top.equalTo(backButton.snp.bottom).offset(10)
+            make.top.equalTo(progressView.snp.bottom)
             make.leading.trailing.bottom.equalToSuperview()
         }
     }

--- a/NyamNyam/NyamNyam/Screens/Setting/Components/SettingListViewModule/Components/SettingWebViewController.swift
+++ b/NyamNyam/NyamNyam/Screens/Setting/Components/SettingListViewModule/Components/SettingWebViewController.swift
@@ -12,6 +12,7 @@ import WebKit
 final class SettingWebViewController: UIViewController {
     var webView: WKWebView!
     var webURL: String = ""
+    private var observation: NSKeyValueObservation?
     
     lazy var backButton = BackButtonView()
     
@@ -51,6 +52,9 @@ final class SettingWebViewController: UIViewController {
             return
         }
     }
+    deinit {
+        observation = nil
+    }
 }
 
 private extension SettingWebViewController {
@@ -78,6 +82,10 @@ private extension SettingWebViewController {
         let AppInfoRequest = URLRequest(url: AppInfoURL!)
         DispatchQueue.main.async {
             self.webView.load(AppInfoRequest)
+        }
+        observation = webView.observe(\WKWebView.estimatedProgress, options: .new) { _, change in
+            self.progressView.progress = Float(self.webView.estimatedProgress)
+            if self.progressView.progress == 1 { self.progressView.progressTintColor = .white }
         }
     }
     

--- a/NyamNyam/NyamNyam/Screens/Setting/Components/SettingListViewModule/Components/SettingWebViewController.swift
+++ b/NyamNyam/NyamNyam/Screens/Setting/Components/SettingListViewModule/Components/SettingWebViewController.swift
@@ -10,8 +10,9 @@ import SnapKit
 import WebKit
 
 final class SettingWebViewController: UIViewController {
-    var webView: WKWebView!
+    
     var webURL: String = ""
+    private var webView: WKWebView!
     private var observation: NSKeyValueObservation?
     
     lazy var backButton = BackButtonView()
@@ -52,9 +53,11 @@ final class SettingWebViewController: UIViewController {
             return
         }
     }
+    
     deinit {
         observation = nil
     }
+    
 }
 
 private extension SettingWebViewController {

--- a/NyamNyam/NyamNyam/Screens/Setting/Components/SettingListViewModule/SettingListTableViewController.swift
+++ b/NyamNyam/NyamNyam/Screens/Setting/Components/SettingListViewModule/SettingListTableViewController.swift
@@ -13,12 +13,12 @@ import MessageUI
 final class SettingListTableViewController: UIViewController {
     
     enum SettingTitle: String {
-//        case linkCAUPortal = "학교 포털 연결"
+        case linkCAUPortal = "학교 포털 연결"
         case privacyPolicy = "개인정보 정책"
         case question = "문의하기"
     }
     
-    private let settingTitle: [SettingTitle] = [.privacyPolicy, .question]
+    private let settingTitle: [SettingTitle] = [.linkCAUPortal, .privacyPolicy, .question]
     
     lazy var tableView: UITableView = {
         let tableView = UITableView(frame: .zero, style: .plain)
@@ -69,8 +69,8 @@ extension SettingListTableViewController: UITableViewDelegate {
         tableView.deselectRow(at: indexPath, animated: true)
         
         switch settingTitle[indexPath.row] {
-//        case .linkCAUPortal:
-//            webViewCellPressed(webURL: "https://mportal.cau.ac.kr/main.do")
+        case .linkCAUPortal:
+            webViewCellPressed(webURL: "https://mportal.cau.ac.kr/main.do")
         case .privacyPolicy:
             webViewCellPressed(webURL: "https://haksik.notion.site/df3546c909294e73af4570b55655514e")
         case .question:

--- a/NyamNyam/NyamNyam/Screens/Setting/Components/SettingListViewModule/SettingListTableViewController.swift
+++ b/NyamNyam/NyamNyam/Screens/Setting/Components/SettingListViewModule/SettingListTableViewController.swift
@@ -72,7 +72,7 @@ extension SettingListTableViewController: UITableViewDelegate {
 //        case .linkCAUPortal:
 //            webViewCellPressed(webURL: "https://mportal.cau.ac.kr/main.do")
         case .privacyPolicy:
-            webViewCellPressed(webURL: "https://drive.google.com/file/d/1ybbnitToIJmFlgmyDz1_4--yovchRBKs/view?usp=share_link")
+            webViewCellPressed(webURL: "https://haksik.notion.site/df3546c909294e73af4570b55655514e")
         case .question:
             touchUpInsideToMailToQuestionPage()
         }


### PR DESCRIPTION
## WebView에 ProgressView를 추가하였습니다.
close #87 


https://user-images.githubusercontent.com/103012087/229035618-44abc8a0-f7b7-49c3-a57f-0ccbafe740fa.mp4



### 1. 기존 개인정보정책, 중앙대 포털 WebView의 상단에 ProgressView를 추가하였습니다.
KVO를 활용하여 현재 `WKWebView`의 이동 상태를 추적하도록 하여 구현하였습니다.
```swift
observation = webView.observe(\WKWebView.estimatedProgress, options: .new) { _, change in
    self.progressView.progress = Float(self.webView.estimatedProgress)
    if self.progressView.progress == 1 { self.progressView.progressTintColor = .white }
}
```
`estimatedProgress` 가 현재 `WKWebView`의 로딩 진행상태 값을 의미합니다.
따라서 `progressView`의 `progress` 값으로 `estimatedProgress`를 주고 `estimatedProgress`의 상태를 추적하도록 하여 로딩 퍼센트만큼의 `progressView`가 표시됩니다.

`progress` 값이 `1`, 즉 로딩이 완료되면 `ProgressView`의 색상을 `white`로 변경하여 숨기도록 하였습니다.
`progressView`를 삭제하지 않고 색상을 변경하여 숨긴 이유는 `webView` 의 위치가 `progressView`의 bottom 값에 의존하기 때문입니다.

### 2. 개인정보 정책의 링크를 변경하고 중앙대 포털 이동 링크를 다시 추가하였습니다.
**개인정보 정책 링크는 기존 노션으로 다시 변경하였습니다.**
노션 페이지의 속도가 느려 구글 드라이브의 페이지를 사용하였는데 ProgressView를 추가하면서
현재 로딩 상태를 사용자가 파악할 수 있기 때문에 다시 변경하였습니다.

## 참고
https://stackoverflow.com/questions/47988125/how-to-monitor-wkwebview-page-load-progress-in-swift