### PR TITLE
날짜가 넘어가면, 이전 날짜가 준비중으로 표시되는 문제를 해결했습니다.

### DIFF
--- a/NyamNyam/NyamNyam/Global/Extension+/Date+.swift
+++ b/NyamNyam/NyamNyam/Global/Extension+/Date+.swift
@@ -26,6 +26,13 @@ extension Date {
         return false
     }
     
+    func isPastDay() -> Bool {
+        guard let today = Calendar.current.date(bySettingHour: 9, minute: 0, second: 0, of: Date()) else { return false }
+        guard let date = Calendar.current.date(bySettingHour: 9, minute: 0, second: 0, of: self) else { return false }
+        if today > date { return true }
+        return false
+    }
+    
     func toTimeString() -> String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "HH:mm"

--- a/NyamNyam/NyamNyam/Screens/Home/ContentCarouselModule/Components/CarouselCell.swift
+++ b/NyamNyam/NyamNyam/Screens/Home/ContentCarouselModule/Components/CarouselCell.swift
@@ -240,6 +240,8 @@ final class CarouselCell: UICollectionViewCell {
                 guard let date = card.date else { return }
                 if date.isToday() {
                     runningStatus = RunningStatus.getRunningStatus(of: card.data?.filter({$0.mealTime == card.mealTime}) ?? [], at: card.cafeteria)
+                } else if date.isPastDay() {
+                    runningStatus = .expired
                 } else {
                     runningStatus = .ready
                 }


### PR DESCRIPTION
close #90 

문제는 #90 에 설명되어 있으니 참고 부탁드립니다.

<br><br>

### 1. 파악된 문제

문제는 오늘 날짜에만 status를 검사하고, 다른 날짜는 무조건 ready 상태로 처리했기 때문이었습니다.

즉 오늘이 아닌 다음 날짜들은 `ready` 상태로 처리해야 하지만, 지난 날짜는 `expired` 로 처리되어야 했는데, 이 부분이 처리되지 않았던 것입니다.

```swift
                guard let date = card.date else { return }
                if date.isToday() {
                    runningStatus = RunningStatus.getRunningStatus(of: card.data?.filter({$0.mealTime == card.mealTime}) ?? [], at: card.cafeteria)
                } else {
                    runningStatus = .ready
                }
```

<br><br>

### 2. 해결

조건을 추가함으로서 해결하였습니다.

먼저 지난 날짜인지를 검사하는 함수를 만들었습니다.

```swift
    func isPastDay() -> Bool {
        guard let today = Calendar.current.date(bySettingHour: 9, minute: 0, second: 0, of: Date()) else { return false }
        guard let date = Calendar.current.date(bySettingHour: 9, minute: 0, second: 0, of: self) else { return false }
        if today > date { return true }
        return false
    }
```

그리고 해당 함수를 이용하여 지난 날짜면 `expired` 상태로 만들어주는 조건을 추가해주었습니다.

```swift
                guard let date = card.date else { return }
                if date.isToday() {
                    runningStatus = RunningStatus.getRunningStatus(of: card.data?.filter({$0.mealTime == card.mealTime}) ?? [], at: card.cafeteria)
                } else if date.isPastDay() {
                    runningStatus = .expired
                } else {
                    runningStatus = .ready
                }
```