### PR TITLE
안성 캠퍼스의 식당 이름이 수정됨에 따라 Json 파싱 함수를 수정하였습니다

### DIFF
--- a/NyamNyam/NyamNyam/Global/Manager/DataManager.swift
+++ b/NyamNyam/NyamNyam/Global/Manager/DataManager.swift
@@ -80,9 +80,9 @@ final class DataManager {
 
 private extension DataManager {
     static func getMealTime(_ mealTime: String, _ cafeteria: String) -> MealTime  {
-        if cafeteria == "(안성)카우버거" {
+        if cafeteria == "(다빈치)카우버거" {
             return .cauburger
-        } else if cafeteria == "(안성)라면" {
+        } else if cafeteria == "(다빈치)라면" {
             return .ramen
         } else {
             switch mealTime {
@@ -122,9 +122,9 @@ private extension DataManager {
             return .staff
         case "카우잇츠(cau eats)":
             return .cauEats
-        case "(안성)카우버거":
+        case "(다빈치)카우버거":
             return .cauBurger
-        case "(안성)라면":
+        case "(다빈치)라면":
             return .ramen
         default:
             return .blueMirA


### PR DESCRIPTION
## 안성 캠퍼스의 식당 이름이 수정됨에 따라 Json 파싱 함수를 수정하였습니다.

안성 캠퍼스의 (안성)라면, (안성)카우버거 가 각각 (다빈치)라면, (다빈치)카우버거 로 변경됨에 따라서
Json 파싱이 되지 않아 학식 데이터를 불러오지 못하는 이슈가 있었습니다.
<img width="378" alt="image" src="https://user-images.githubusercontent.com/103012087/235585833-6012660c-d267-42dd-aae2-e743395ce40a.png">

따라서 `DataManager`의 `getCafeteria()` 와 `getMealTime()` 의 Json 파싱 부분을 수정하였습니다.