### PR TITLE
새로운 카페테리아 University Club을 추가하였습니다

### DIFF
--- a/NyamNyam/NyamNyam/Application/AppDelegate.swift
+++ b/NyamNyam/NyamNyam/Application/AppDelegate.swift
@@ -28,7 +28,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                                                         Cafeteria.blueMirA.rawValue,
                                                         Cafeteria.blueMirB.rawValue,
                                                         Cafeteria.student.rawValue,
-                                                        Cafeteria.staff.rawValue]
+                                                        Cafeteria.staff.rawValue,
+                                                        Cafeteria.universityClub.rawValue]
                 UserDefaults.standard.ansungCafeteria = [Cafeteria.cauEats.rawValue,
                                                          Cafeteria.cauBurger.rawValue,
                                                          Cafeteria.ramen.rawValue]

--- a/NyamNyam/NyamNyam/Global/Manager/DataManager.swift
+++ b/NyamNyam/NyamNyam/Global/Manager/DataManager.swift
@@ -129,7 +129,7 @@ private extension DataManager {
         case "(안성)라면":
             return .ramen
         default:
-            return .blueMirA
+            return .none
         }
     }
     

--- a/NyamNyam/NyamNyam/Global/Manager/DataManager.swift
+++ b/NyamNyam/NyamNyam/Global/Manager/DataManager.swift
@@ -120,6 +120,8 @@ private extension DataManager {
             return .student
         case "교직원식당(303관B1층)":
             return .staff
+        case "University Club(102관11층)":
+            return .universityClub
         case "카우잇츠(cau eats)":
             return .cauEats
         case "(안성)카우버거":

--- a/NyamNyam/NyamNyam/Network/Model/Meal.swift
+++ b/NyamNyam/NyamNyam/Network/Model/Meal.swift
@@ -21,6 +21,7 @@ enum Cafeteria: String {
     case blueMirB
     case student
     case staff
+    case universityClub
     case cauEats
     case cauBurger
     case ramen

--- a/NyamNyam/NyamNyam/Network/Model/Meal.swift
+++ b/NyamNyam/NyamNyam/Network/Model/Meal.swift
@@ -25,6 +25,7 @@ enum Cafeteria: String {
     case cauEats
     case cauBurger
     case ramen
+    case none
 }
 
 enum MealType {

--- a/NyamNyam/NyamNyam/Screens/Home/Components/OptionSelectModule/CafeteriaSelectView.swift
+++ b/NyamNyam/NyamNyam/Screens/Home/Components/OptionSelectModule/CafeteriaSelectView.swift
@@ -70,6 +70,8 @@ final class CafeteriaSelectView: UIScrollView {
                 name = "카우버거"
             case .ramen:
                 name = "라면"
+            case .none:
+                name = ""
             }
             let button = CafeteriaButton(buttonIndex: idx, name: name)
             button.addTarget(self, action: #selector(cafeteriaButtonPressed), for: .touchUpInside)

--- a/NyamNyam/NyamNyam/Screens/Home/Components/OptionSelectModule/CafeteriaSelectView.swift
+++ b/NyamNyam/NyamNyam/Screens/Home/Components/OptionSelectModule/CafeteriaSelectView.swift
@@ -62,6 +62,8 @@ final class CafeteriaSelectView: UIScrollView {
                 name = "학생식당"
             case .staff:
                 name = "교직원"
+            case .universityClub:
+                name = "University Club"
             case .cauEats:
                 name = "카우이츠"
             case .cauBurger:

--- a/NyamNyam/NyamNyam/Screens/Home/ContentCarouselModule/Components/ContentStackView.swift
+++ b/NyamNyam/NyamNyam/Screens/Home/ContentCarouselModule/Components/ContentStackView.swift
@@ -49,7 +49,7 @@ final class ContentStackView: UIView {
     private func setStackViewContents() {
         guard let data = data else { return }
         var colCount = 2
-        if data.cafeteria == .blueMirB { colCount = 1 }
+        if data.cafeteria == .blueMirB || data.cafeteria == .universityClub { colCount = 1 }
         for row in 0..<Int(round(Double(Double(data.menu.count) / Double(colCount)))) {
             let rowStackView = UIStackView()
             rowStackView.axis = .horizontal

--- a/NyamNyam/NyamNyam/Screens/Home/ContentCarouselModule/ContentCarouselModuleViewController.swift
+++ b/NyamNyam/NyamNyam/Screens/Home/ContentCarouselModule/ContentCarouselModuleViewController.swift
@@ -143,6 +143,8 @@ extension ContentCarouselModuleViewController: UICollectionViewDataSource {
             return "707관"
         case .ramen:
             return "707관"
+        case .none:
+            return ""
         }
     }
 }

--- a/NyamNyam/NyamNyam/Screens/Home/ContentCarouselModule/ContentCarouselModuleViewController.swift
+++ b/NyamNyam/NyamNyam/Screens/Home/ContentCarouselModule/ContentCarouselModuleViewController.swift
@@ -135,6 +135,8 @@ extension ContentCarouselModuleViewController: UICollectionViewDataSource {
             return "법학관(303) B1층"
         case .staff:
             return "법학관(303) B1층"
+        case .universityClub:
+            return "R&D센터(102) 11층"
         case .cauEats:
             return "707관"
         case .cauBurger:

--- a/NyamNyam/NyamNyam/Screens/Setting/Components/SetCafeteriaOrderModule/SetCafeteriaOrderTableViewController.swift
+++ b/NyamNyam/NyamNyam/Screens/Setting/Components/SetCafeteriaOrderModule/SetCafeteriaOrderTableViewController.swift
@@ -25,6 +25,8 @@ final class SetCafeteriaOrderTableViewController: UIViewController {
             return "학생식당"
         case "staff":
             return "교직원"
+        case "universityClub":
+            return "University Club"
         case "cauEats":
             return "카우이츠"
         case "cauBurger":


### PR DESCRIPTION
close #98 

## University Club이라는 서울 캠퍼스의 카페테리아를 추가하였습니다.
중앙대학교 포털에서 University Club이라는 카페테리아가 운영됨에 따라 추가하였습니다.
크롤러 확인 결과 정상적으로 크롤링 해오는 것을 확인했습니다 따라서 단순히 case 추가만 하였습니다.
<br>
<img src = "https://github.com/HipstuCAU/nyam_nyam/assets/103012087/dfc1b682-d6b1-4088-9a93-9befc9b42895" width = 200><img src = "https://github.com/HipstuCAU/nyam_nyam/assets/103012087/701f19b7-47f4-4c23-bd5e-d053b63b2e3f" width = 200>

- UserDefaults와 Cafeteria 모델 등 각 사용되는 부분에 추가하였습니다.
- 설정창에서도 추가 후에 카페테리아 순서 변경시 적용되는 것을 확인하였습니다.

## 추가 수정사항
[6a382e4](https://github.com/HipstuCAU/nyam_nyam/pull/99/commits/6a382e45e5c13daf22944e7ffb4ac76a756e0795)

<img src = "https://github.com/HipstuCAU/nyam_nyam/assets/103012087/7e0683d6-dc8e-4a93-9cc8-2d5c345dde9c" width = 200>

- University Club의 각 메뉴가 하나뿐인 관계로 `colCount`를 1로 수정하여 메뉴가 하나로 들어가고 잘리지 않도록 하였습니다.

```swift
if data.cafeteria == .blueMirB { colCount = 1 }
```
이 부분을

```swift
if data.cafeteria == .blueMirB || data.cafeteria == .universityClub { colCount = 1 }
```
으로 수정하여 생활관B의 케이스 외에도 추가하였습니다.

## 추가 수정사항
[b09dbb7](https://github.com/HipstuCAU/nyam_nyam/pull/99/commits/b09dbb7113cd47cb1d0fde5d616a71793faea8fd)

`university club` 같이 `cafeteria case`가 들어가있지 않은 상황인 경우에 `default`값으로 `data`가 들어가게 되어서 다른 카페테리아로 반영되는 경우가 있었습니다.

아래와 같이 생활관 식단에 현재 `cafeteria case`에 추가되어있지 않은 `university club`의 데이터가 `default`로 설정된 생활관 식당에 들어가서 발생한 오류였습니다.

<img src = "https://github.com/HipstuCAU/nyam_nyam/assets/103012087/513a5ace-443e-4b90-a33f-507a0dd742d4" width = 250><img width="250" alt="image" src="https://github.com/HipstuCAU/nyam_nyam/assets/103012087/ec27211b-7528-4aba-af19-8159c089f886">

```swift
    static func getCafeteria(_ cafeteria: String) -> Cafeteria {
        switch cafeteria {
        case "생활관식당(블루미르308관)":
            return .blueMirA
        case "참슬기식당(310관 B4층)":
            return .chamseulgi
        case "생활관식당(블루미르309관)":
            return .blueMirB
        case "학생식당(303관B1층)":
            return .student
        case "교직원식당(303관B1층)":
            return .staff
        case "University Club(102관11층)":
            return .universityClub
        case "카우잇츠(cau eats)":
            return .cauEats
        case "(안성)카우버거":
            return .cauBurger
        case "(안성)라면":
            return .ramen
        default:
            return .blueMirA //cafeteria case가 없는 데이터의 경우 생활관으로 지정됨
        }
    }
```

따라서 `Cafeteria` 모델에 `.none` case를 추가하여 case에 없는 데이터가 들어와도 다른 카페테리아로 반영되지 않도록 수정하였습니다.

- .none를 추가하면서 다른 switch문도 변경하였습니다. 확인 부탁드립니다 !


## + 리뷰 요청 사항
- View에 표시되는 카페테리아 이름을 우선 `University Club` 그대로 사용하였습니다. 다르다면 확인부탁드립니다.
- 위치표기를 `R&D센터(102) 11층`으로 하였습니다. 오기입일시에 수정부탁드립니다.
- 메뉴가 하나씩이라 여백이 좀 있어보이는데 이 부분도 혹시 어색하다면 확인 부탁드립니다.